### PR TITLE
update guzzle requirements to ^7.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "ext-json": "*",
         "ext-openssl": "*",
         "ext-SimpleXML": "*",
-        "guzzlehttp/guzzle": "^6.3.3",
+        "guzzlehttp/guzzle": "^7.0.0",
         "symfony/http-foundation": "^5.0",
         "symfony/serializer": "^5.0"
     },


### PR DESCRIPTION
Too many modern libraries are locked to v ^7.0.0 of guzzle, thus it's making it difficult to include the library while these dependencies exist in projects, so I changed the guzzle version to ^7.0.0.