### PR TITLE
Refactor methods for better testing

### DIFF
--- a/examples/akbank/_payment_config.php
+++ b/examples/akbank/_payment_config.php
@@ -1,5 +1,6 @@
 <?php
 
+use Mews\Pos\Entity\Card\AbstractCreditCard;
 use Mews\Pos\Gateways\AbstractGateway;
 
 require __DIR__.'/../_main_config.php';
@@ -105,6 +106,6 @@ $testCards = [
         12,
         '000',
         'John Doe',
-        'visa'
+        AbstractCreditCard::CARD_TYPE_VISA
     ),
 ];

--- a/examples/finansbank-payfor/_payment_config.php
+++ b/examples/finansbank-payfor/_payment_config.php
@@ -1,5 +1,6 @@
 <?php
 
+use Mews\Pos\Entity\Card\AbstractCreditCard;
 use Mews\Pos\Gateways\AbstractGateway;
 
 require __DIR__.'/../_main_config.php';
@@ -98,6 +99,6 @@ $testCards = [
         1,
         '123',
         'John Doe',
-        'visa'
+        AbstractCreditCard::CARD_TYPE_VISA
     ),
 ];

--- a/examples/garanti/_payment_config.php
+++ b/examples/garanti/_payment_config.php
@@ -1,5 +1,6 @@
 <?php
 
+use Mews\Pos\Entity\Card\AbstractCreditCard;
 use Mews\Pos\Gateways\AbstractGateway;
 
 require __DIR__.'/../_main_config.php';
@@ -93,6 +94,6 @@ $testCards = [
         12,
         '000',
         'John Doe',
-        'visa'
+        AbstractCreditCard::CARD_TYPE_VISA
     ),
 ];

--- a/examples/interpos/_payment_config.php
+++ b/examples/interpos/_payment_config.php
@@ -1,5 +1,6 @@
 <?php
 
+use Mews\Pos\Entity\Card\AbstractCreditCard;
 use Mews\Pos\Gateways\AbstractGateway;
 
 require __DIR__.'/../_main_config.php';
@@ -92,7 +93,7 @@ $testCards = [
         11,
         592,
         'John Doe',
-        'visa'
+        AbstractCreditCard::CARD_TYPE_VISA
     ),
     'visa2' => new \Mews\Pos\Entity\Card\CreditCardInterPos(
         '4090700101174272',
@@ -100,6 +101,6 @@ $testCards = [
         12,
         104,
         'John Doe',
-        'visa'
+        AbstractCreditCard::CARD_TYPE_VISA
     ),
 ];

--- a/examples/vakifbank/_payment_config.php
+++ b/examples/vakifbank/_payment_config.php
@@ -1,5 +1,6 @@
 <?php
 
+use Mews\Pos\Entity\Card\AbstractCreditCard;
 use Mews\Pos\Gateways\AbstractGateway;
 
 require __DIR__.'/../_main_config.php';
@@ -90,6 +91,6 @@ $testCards = [
         11,
         454,
         'John Doe',
-        'visa'
+        AbstractCreditCard::CARD_TYPE_VISA
     ),
 ];

--- a/examples/ykb/3d/_config.php
+++ b/examples/ykb/3d/_config.php
@@ -5,7 +5,7 @@ use Mews\Pos\Gateways\AbstractGateway;
 
 require '../_payment_config.php';
 
-$baseUrl = $hostUrl.'/3d/';
+$baseUrl = $bankTestsUrl.'/3d/';
 
 $account = AccountFactory::createPosNetAccount(
     'yapikredi',

--- a/examples/ykb/_payment_config.php
+++ b/examples/ykb/_payment_config.php
@@ -1,5 +1,6 @@
 <?php
 
+use Mews\Pos\Entity\Card\AbstractCreditCard;
 use Mews\Pos\Gateways\AbstractGateway;
 
 require __DIR__.'/../_main_config.php';
@@ -78,6 +79,6 @@ $testCards = [
         11,
         454,
         'John Doe',
-        'visa'
+        AbstractCreditCard::CARD_TYPE_VISA
     ),
 ];

--- a/src/Entity/Card/AbstractCreditCard.php
+++ b/src/Entity/Card/AbstractCreditCard.php
@@ -7,6 +7,11 @@ namespace Mews\Pos\Entity\Card;
  */
 abstract class AbstractCreditCard
 {
+    public const CARD_TYPE_VISA = 'visa';
+    public const CARD_TYPE_MASTERCARD = 'master';
+    public const CARD_TYPE_AMEX = 'amex';
+    public const CARD_TYPE_TROY = 'troy';
+
     /**
      * 16 digit credit card number without spaces
      * @var string

--- a/src/Entity/Card/CreditCardEstPos.php
+++ b/src/Entity/Card/CreditCardEstPos.php
@@ -8,8 +8,8 @@ namespace Mews\Pos\Entity\Card;
 class CreditCardEstPos extends AbstractCreditCard
 {
     private $cardTypeToCodeMapping = [
-        'visa'   => '1',
-        'master' => '2',
+        self::CARD_TYPE_VISA       => '1',
+        self::CARD_TYPE_MASTERCARD => '2',
     ];
 
     /**

--- a/src/Entity/Card/CreditCardInterPos.php
+++ b/src/Entity/Card/CreditCardInterPos.php
@@ -8,9 +8,9 @@ namespace Mews\Pos\Entity\Card;
 class CreditCardInterPos extends AbstractCreditCard
 {
     private $cardTypeToCodeMapping = [
-        'visa'   => '0',
-        'master' => '1',
-        'amex'   => '3',
+        self::CARD_TYPE_VISA       => '0',
+        self::CARD_TYPE_MASTERCARD => '1',
+        self::CARD_TYPE_AMEX       => '3',
     ];
 
     /**

--- a/src/Entity/Card/CreditCardVakifBank.php
+++ b/src/Entity/Card/CreditCardVakifBank.php
@@ -9,10 +9,10 @@ namespace Mews\Pos\Entity\Card;
 class CreditCardVakifBank extends AbstractCreditCard
 {
     private static $cardTypeToCodeMapping = [
-        'visa'   => '100',
-        'master' => '200',
-        'troy'   => '300',
-        'amex'   => '400',
+        self::CARD_TYPE_VISA       => '100',
+        self::CARD_TYPE_MASTERCARD => '200',
+        self::CARD_TYPE_TROY       => '300',
+        self::CARD_TYPE_AMEX       => '400',
     ];
 
     /**

--- a/src/Gateways/EstPos.php
+++ b/src/Gateways/EstPos.php
@@ -160,11 +160,9 @@ class EstPos extends AbstractGateway
     /**
      * @inheritDoc
      */
-    public function make3DPayment()
+    public function make3DPayment(Request $request)
     {
-        $request = Request::createFromGlobals();
-
-
+        $provisionResponse = null;
         if ($this->check3DHash($request->request->all())) {
             if ($request->request->get('ProcReturnCode') !== '00') {
                 /**
@@ -175,10 +173,10 @@ class EstPos extends AbstractGateway
                  */
             }
             $contents = $this->create3DPaymentXML($request->request->all());
-            $this->send($contents);
+            $provisionResponse = $this->send($contents);
         }
 
-        $this->response = $this->map3DPaymentData($request->request->all(), $this->data);
+        $this->response = $this->map3DPaymentData($request->request->all(), $provisionResponse);
 
         return $this;
     }
@@ -186,10 +184,8 @@ class EstPos extends AbstractGateway
     /**
      * @inheritDoc
      */
-    public function make3DPayPayment()
+    public function make3DPayPayment(Request $request)
     {
-        $request = Request::createFromGlobals();
-
         $this->response = $this->map3DPayResponseData($request->request->all());
 
         return $this;
@@ -198,9 +194,9 @@ class EstPos extends AbstractGateway
     /**
      * @inheritDoc
      */
-    public function make3DHostPayment()
+    public function make3DHostPayment(Request $request)
     {
-        return $this->make3DPayPayment();
+        return $this->make3DPayPayment($request);
     }
 
     /**
@@ -253,7 +249,7 @@ class EstPos extends AbstractGateway
     /**
      * @inheritDoc
      */
-    public function send($contents)
+    public function send($contents, ?string $url = null)
     {
         $client = new Client();
 
@@ -263,7 +259,7 @@ class EstPos extends AbstractGateway
 
         $this->data = $this->XMLStringToObject($response->getBody()->getContents());
 
-        return $this;
+        return $this->data;
     }
 
     /**
@@ -273,9 +269,9 @@ class EstPos extends AbstractGateway
     {
         $xml = $this->createHistoryXML($meta);
 
-        $this->send($xml);
+        $bankResponse = $this->send($xml);
 
-        $this->response = $this->mapHistoryResponse($this->data);
+        $this->response = $this->mapHistoryResponse($bankResponse);
 
         return $this;
     }

--- a/src/Gateways/GarantiPos.php
+++ b/src/Gateways/GarantiPos.php
@@ -142,16 +142,16 @@ class GarantiPos extends AbstractGateway
     /**
      * @inheritDoc
      */
-    public function make3DPayment()
+    public function make3DPayment(Request $request)
     {
-        $request = Request::createFromGlobals();
+        $bankResponse = null;
         //TODO hash check
         if (in_array($request->get('mdstatus'), [1, 2, 3, 4])) {
             $contents = $this->create3DPaymentXML($request->request->all());
-            $this->send($contents);
+            $bankResponse = $this->send($contents);
         }
 
-        $this->response = (object) $this->map3DPaymentData($request->request->all(), $this->data);
+        $this->response = (object) $this->map3DPaymentData($request->request->all(), $bankResponse);
 
         return $this;
     }
@@ -159,10 +159,8 @@ class GarantiPos extends AbstractGateway
     /**
      * @inheritDoc
      */
-    public function make3DPayPayment()
+    public function make3DPayPayment(Request $request)
     {
-        $request = Request::createFromGlobals();
-
         $this->response = (object) $this->map3DPayResponseData($request->request->all());
 
         return $this;
@@ -176,9 +174,9 @@ class GarantiPos extends AbstractGateway
     {
         $xml = $this->createHistoryXML($meta);
 
-        $this->send($xml);
+        $bankResponse = $this->send($xml);
 
-        $this->response = $this->mapHistoryResponse($this->data);
+        $this->response = $this->mapHistoryResponse($bankResponse);
 
         return $this;
     }
@@ -186,7 +184,7 @@ class GarantiPos extends AbstractGateway
     /**
      * @inheritDoc
      */
-    public function send($contents)
+    public function send($contents, ?string $url = null)
     {
         $client = new Client();
 
@@ -196,7 +194,7 @@ class GarantiPos extends AbstractGateway
 
         $this->data = $this->XMLStringToObject($response->getBody()->getContents());
 
-        return $this;
+        return $this->data;
     }
 
     /**
@@ -247,7 +245,7 @@ class GarantiPos extends AbstractGateway
      * TODO
      * @inheritDoc
      */
-    public function make3DHostPayment()
+    public function make3DHostPayment(Request $request)
     {
         throw new NotImplementedException();
     }

--- a/src/Gateways/PayForPos.php
+++ b/src/Gateways/PayForPos.php
@@ -138,18 +138,17 @@ class PayForPos extends AbstractGateway
     /**
      * @inheritDoc
      */
-    public function make3DPayment()
+    public function make3DPayment(Request $request)
     {
-        $request = Request::createFromGlobals();
-
+        $bankResponse = null;
         //if customer 3d verification passed finish payment
         if ($this->check3DHash($request->request->all()) && '1' === $request->get('3DStatus')) {
             //valid ProcReturnCode is V033 in case of success 3D Authentication
             $contents = $this->create3DPaymentXML($request->request->all());
-            $this->send($contents);
+            $bankResponse = $this->send($contents);
         }
 
-        $this->response = $this->map3DPaymentData($request->request->all(), $this->data);
+        $this->response = $this->map3DPaymentData($request->request->all(), $bankResponse);
 
         return $this;
     }
@@ -157,10 +156,8 @@ class PayForPos extends AbstractGateway
     /**
      * @inheritDoc
      */
-    public function make3DPayPayment()
+    public function make3DPayPayment(Request $request)
     {
-        $request = Request::createFromGlobals();
-
         $this->response = $this->map3DPayResponseData($request->request->all());
 
         return $this;
@@ -169,9 +166,9 @@ class PayForPos extends AbstractGateway
     /**
      * @inheritDoc
      */
-    public function make3DHostPayment()
+    public function make3DHostPayment(Request $request)
     {
-        return $this->make3DPayPayment();
+        return $this->make3DPayPayment($request);
     }
 
     /**
@@ -235,7 +232,7 @@ class PayForPos extends AbstractGateway
     /**
      * @inheritDoc
      */
-    public function send($postData)
+    public function send($postData, ?string $url = null)
     {
         $client = new Client();
 
@@ -266,7 +263,7 @@ class PayForPos extends AbstractGateway
             $this->data = (object) json_decode($contents);
         }
 
-        return $this;
+        return $this->data;
     }
 
     /**

--- a/src/Gateways/VakifBankPos.php
+++ b/src/Gateways/VakifBankPos.php
@@ -108,9 +108,9 @@ class VakifBankPos extends AbstractGateway
     /**
      * @inheritDoc
      */
-    public function make3DPayment()
+    public function make3DPayment(Request $request)
     {
-        $request = Request::createFromGlobals()->request;
+        $request = $request->request;
         $gatewayResponse = $this->emptyStringsToNull($request->all());
         // 3D authorization failed
         if ('Y' !== $gatewayResponse['Status'] && 'A' !== $gatewayResponse['Status']) {
@@ -127,9 +127,9 @@ class VakifBankPos extends AbstractGateway
         }
 
         $contents = $this->create3DPaymentXML($gatewayResponse);
-        $this->send($contents);
+        $bankResponse = $this->send($contents);
 
-        $this->response = $this->map3DPaymentData($gatewayResponse, $this->data);
+        $this->response = $this->map3DPaymentData($gatewayResponse, $bankResponse);
 
         return $this;
     }
@@ -138,7 +138,7 @@ class VakifBankPos extends AbstractGateway
      * TODO
      * @inheritDoc
      */
-    public function make3DPayPayment()
+    public function make3DPayPayment(Request $request)
     {
         throw new UnsupportedPaymentModelException();
     }
@@ -147,7 +147,7 @@ class VakifBankPos extends AbstractGateway
      * TODO
      * @inheritDoc
      */
-    public function make3DHostPayment()
+    public function make3DHostPayment(Request $request)
     {
         throw new UnsupportedPaymentModelException();
     }
@@ -217,7 +217,7 @@ class VakifBankPos extends AbstractGateway
     {
         $requestData = $this->create3DEnrollmentCheckData();
 
-        return $this->send($requestData, $this->get3DGatewayURL())->data;
+        return $this->send($requestData, $this->get3DGatewayURL());
     }
 
     /**
@@ -267,7 +267,7 @@ class VakifBankPos extends AbstractGateway
 
         $this->data = $this->emptyStringsToNull($this->data);
 
-        return $this;
+        return $this->data;
     }
 
     /**

--- a/src/PosInterface.php
+++ b/src/PosInterface.php
@@ -7,6 +7,7 @@ use Mews\Pos\Entity\Account\AbstractPosAccount;
 use Mews\Pos\Entity\Card\AbstractCreditCard;
 use Mews\Pos\Exceptions\UnsupportedPaymentModelException;
 use Mews\Pos\Gateways\AbstractGateway;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Interface PosInterface
@@ -53,37 +54,41 @@ interface PosInterface
 
     /**
      * Make 3D Payment
+     * @param Request $request
      *
      * @return AbstractGateway
      *
      * @throws GuzzleException
      */
-    public function make3DPayment();
+    public function make3DPayment(Request $request);
 
     /**
      * Make 3D Pay Payment
+     * @param Request $request
      *
      * @return AbstractGateway
      */
-    public function make3DPayPayment();
+    public function make3DPayPayment(Request $request);
 
     /**
      * Just returns formatted data of host payment response
+     * @param Request $request
      *
      * @return AbstractGateway
      */
-    public function make3DHostPayment();
+    public function make3DHostPayment(Request $request);
 
     /**
      * Send contents to WebService
      *
-     * @param $contents
+     * @param array|string $contents
+     * @param string|null  $url
      *
-     * @return AbstractGateway
+     * @return mixed
      *
      * @throws GuzzleException
      */
-    public function send($contents);
+    public function send($contents, ?string $url = null);
 
     /**
      * Prepare Order

--- a/tests/Entity/Card/CreditCardEstPosTest.php
+++ b/tests/Entity/Card/CreditCardEstPosTest.php
@@ -2,6 +2,7 @@
 
 namespace Mews\Pos\Tests\Entity\Card;
 
+use Mews\Pos\Entity\Card\AbstractCreditCard;
 use Mews\Pos\Entity\Card\CreditCardEstPos;
 use PHPUnit\Framework\TestCase;
 
@@ -9,7 +10,7 @@ class CreditCardEstPosTest extends TestCase
 {
     public function testGetCardCode()
     {
-        $card = new CreditCardEstPos('1111222233334444', '02', '03', '111', 'ahmet mehmet', 'visa');
+        $card = new CreditCardEstPos('1111222233334444', '02', '03', '111', 'ahmet mehmet', AbstractCreditCard::CARD_TYPE_VISA);
         $this->assertEquals('1', $card->getCardCode());
     }
 }

--- a/tests/Entity/Card/CreditCardGarantiPosTest.php
+++ b/tests/Entity/Card/CreditCardGarantiPosTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Mews\Pos\Tests\Entity\Card;
+
+use Mews\Pos\Entity\Card\AbstractCreditCard;
+use Mews\Pos\Entity\Card\CreditCardGarantiPos;
+use PHPUnit\Framework\TestCase;
+
+class CreditCardGarantiPosTest extends TestCase
+{
+    public function testExpDate()
+    {
+        $card = new CreditCardGarantiPos('1111222233334444', '02', '03', '111', 'ahmet mehmet', AbstractCreditCard::CARD_TYPE_VISA);
+        $this->assertEquals('0302', $card->getExpirationDate());
+    }
+}

--- a/tests/Entity/Card/CreditCardInterPosTest.php
+++ b/tests/Entity/Card/CreditCardInterPosTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Mews\Pos\Tests\Entity\Card;
+
+use Mews\Pos\Entity\Card\AbstractCreditCard;
+use Mews\Pos\Entity\Card\CreditCardInterPos;
+use PHPUnit\Framework\TestCase;
+
+class CreditCardInterPosTest extends TestCase
+{
+    public function testExpDate()
+    {
+        $card = new CreditCardInterPos('1111222233334444', '02', '03', '111', 'ahmet mehmet', AbstractCreditCard::CARD_TYPE_VISA);
+        $this->assertEquals('0302', $card->getExpirationDate());
+    }
+
+    public function testGetCardCode()
+    {
+        $card = new CreditCardInterPos('1111222233334444', '02', '03', '111', 'ahmet mehmet', AbstractCreditCard::CARD_TYPE_MASTERCARD);
+        $this->assertEquals('1', $card->getCardCode());
+    }
+}

--- a/tests/Entity/Card/CreditCardPayForTest.php
+++ b/tests/Entity/Card/CreditCardPayForTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Mews\Pos\Tests\Entity\Card;
+
+use Mews\Pos\Entity\Card\AbstractCreditCard;
+use Mews\Pos\Entity\Card\CreditCardPayFor;
+use PHPUnit\Framework\TestCase;
+
+class CreditCardPayForTest extends TestCase
+{
+    public function testExpDate()
+    {
+        $card = new CreditCardPayFor('1111222233334444', '02', '03', '111', 'ahmet mehmet', AbstractCreditCard::CARD_TYPE_VISA);
+        $this->assertEquals('0302', $card->getExpirationDate());
+    }
+}

--- a/tests/Entity/Card/CreditCardVakifBankTest.php
+++ b/tests/Entity/Card/CreditCardVakifBankTest.php
@@ -3,6 +3,7 @@
 
 namespace Mews\Pos\Tests\Entity\Card;
 
+use Mews\Pos\Entity\Card\AbstractCreditCard;
 use Mews\Pos\Entity\Card\CreditCardVakifBank;
 use PHPUnit\Framework\TestCase;
 
@@ -17,7 +18,7 @@ class CreditCardVakifBankTest extends TestCase
 
     public function testTypeCode()
     {
-        $card = new CreditCardVakifBank('1111222233334444', '02', '03', '111', 'ahmet mehmet', 'master');
+        $card = new CreditCardVakifBank('1111222233334444', '02', '03', '111', 'ahmet mehmet', AbstractCreditCard::CARD_TYPE_MASTERCARD);
 
         $this->assertEquals('200', $card->getCardCode());
 

--- a/tests/Gateways/EstPostTest.php
+++ b/tests/Gateways/EstPostTest.php
@@ -3,6 +3,7 @@
 namespace Mews\Pos\Tests\Gateways;
 
 use Mews\Pos\Entity\Account\EstPosAccount;
+use Mews\Pos\Entity\Card\AbstractCreditCard;
 use Mews\Pos\Entity\Card\CreditCardEstPos;
 use Mews\Pos\Factory\AccountFactory;
 use Mews\Pos\Factory\PosFactory;
@@ -52,7 +53,7 @@ class EstPostTest extends TestCase
             EstPos::LANG_TR
         );
 
-        $this->card = new CreditCardEstPos('5555444433332222', '21', '12', '122', 'ahmet', 'visa');
+        $this->card = new CreditCardEstPos('5555444433332222', '21', '12', '122', 'ahmet', AbstractCreditCard::CARD_TYPE_VISA);
 
         $this->order = [
             'id'          => 'order222',

--- a/tests/Gateways/InterPosTest.php
+++ b/tests/Gateways/InterPosTest.php
@@ -2,6 +2,7 @@
 
 namespace Mews\Pos\Tests\Gateways;
 
+use GuzzleHttp\Exception\GuzzleException;
 use Mews\Pos\Entity\Account\InterPosAccount;
 use Mews\Pos\Entity\Card\CreditCardInterPos;
 use Mews\Pos\Factory\AccountFactory;
@@ -9,6 +10,7 @@ use Mews\Pos\Factory\PosFactory;
 use Mews\Pos\Gateways\AbstractGateway;
 use Mews\Pos\Gateways\InterPos;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @covers \Mews\Pos\Gateways\InterPos
@@ -330,6 +332,144 @@ class InterPosTest extends TestCase
 
         $expectedData = $this->getSampleRefundXMLData($pos->getOrder(), $pos->getAccount());
         $this->assertEquals($expectedData, $actual);
+    }
+
+    /**
+     * @return void
+     *
+     * @throws GuzzleException
+     */
+    public function testMake3DPaymentAuthFail()
+    {
+        $this->pos->prepare($this->order, AbstractGateway::TX_PAY, $this->card);
+        $request = Request::create('', 'POST', [
+            'Version' => '',
+            'MerchantID' => '',
+            'ShopCode' => '3123',
+            'TxnStat' => 'N',
+            'MD' => '',
+            'RetCode' => '',
+            'RetDet' => '',
+            'VenderCode' => '',
+            'Eci' => '',
+            'PayerAuthenticationCode' => '',
+            'PayerTxnId' => '',
+            'CavvAlg' => '',
+            'PAResVerified' => 'False',
+            'PAResSyntaxOK' => 'False',
+            'Expiry' => '****',
+            'Pan' => '409070******0057',
+            'OrderId' => '202204155912',
+            'PurchAmount' => '30',
+            'Exponent' => '',
+            'Description' => '',
+            'Description2' => '',
+            'Currency' => '949',
+            'OkUrl' => 'http://localhost/interpos/3d/response.php',
+            'FailUrl' => 'http://localhost/interpos/3d/response.php',
+            '3DStatus' => '0',
+            'AuthCode' => '',
+            'HostRefNum' => 'hostid',
+            'TransId' => '',
+            'TRXDATE' => '',
+            'CardHolderName' => '',
+            'mdStatus' => '0',
+            'ProcReturnCode' => '81',
+            'TxnResult' => '',
+            'ErrorMessage' => 'Terminal Aktif Degil',
+            'ErrorCode' => 'B810002',
+            'Response' => '',
+            'HASH' => '4hSLIFy/RNlEdB7sUYNnP7kAqzM=',
+            'HASHPARAMS' => 'Version:PurchAmount:Exponent:Currency:OkUrl:FailUrl:MD:OrderId:ProcReturnCode:Response:mdStatus:',
+            'HASHPARAMSVAL' => '30949http://localhost/interpos/3d/response.phphttp://localhost/interpos/3d/response.php202204155912810',
+        ]);
+
+        $this->pos->make3DPayment($request);
+        $result = $this->pos->getResponse();
+        $this->assertIsObject($result);
+        $result = (array) $result;
+
+        $this->assertSame('declined', $result['status']);
+        $this->assertSame('81', $result['proc_return_code']);
+        $this->assertSame('B810002', $result['error_code']);
+        $this->assertSame('202204155912', $result['order_id']);
+        $this->assertSame('Auth', $result['transaction']);
+        $this->assertSame('409070******0057', $result['masked_number']);
+        $this->assertSame('30', $result['amount']);
+        $this->assertSame('TRY', $result['currency']);
+        $this->assertSame('4hSLIFy/RNlEdB7sUYNnP7kAqzM=', $result['hash']);
+        $this->assertSame('Terminal Aktif Degil', $result['error_message']);
+        $this->assertNotEmpty($result['3d_all']);
+        $this->assertNull($result['all']);
+    }
+
+    /**
+     * @return void
+     *
+     * @throws GuzzleException
+     */
+    public function testMake3DPayPaymentFail()
+    {
+        $this->pos->prepare($this->order, AbstractGateway::TX_PAY, $this->card);
+        $request = Request::create('', 'POST', [
+            'Version' => '',
+            'MerchantID' => '',
+            'ShopCode' => '3123',
+            'TxnStat' => 'N',
+            'MD' => '',
+            'RetCode' => '',
+            'RetDet' => '',
+            'VenderCode' => '',
+            'Eci' => '',
+            'PayerAuthenticationCode' => '',
+            'PayerTxnId' => '',
+            'CavvAlg' => '',
+            'PAResVerified' => 'False',
+            'PAResSyntaxOK' => 'False',
+            'Expiry' => '****',
+            'Pan' => '409070******0057',
+            'OrderId' => '202204155912',
+            'PurchAmount' => '30',
+            'Exponent' => '',
+            'Description' => '',
+            'Description2' => '',
+            'Currency' => '949',
+            'OkUrl' => 'http://localhost/interpos/3d-pay/response.php',
+            'FailUrl' => 'http://localhost/interpos/3d-pay/response.php',
+            '3DStatus' => '0',
+            'AuthCode' => '',
+            'HostRefNum' => 'hostid',
+            'TransId' => '',
+            'TRXDATE' => '',
+            'CardHolderName' => '',
+            'mdStatus' => '0',
+            'ProcReturnCode' => '81',
+            'TxnResult' => '',
+            'ErrorMessage' => 'Terminal Aktif Degil',
+            'ErrorCode' => 'B810002',
+            'Response' => '',
+            'HASH' => 'klXFUEWTgMc6pRZJFsQRMTOa9us=',
+            'HASHPARAMS' => 'Version:PurchAmount:Exponent:Currency:OkUrl:FailUrl:MD:OrderId:ProcReturnCode:Response:mdStatus:',
+            'HASHPARAMSVAL' => '30949http://localhost/interpos/3d-pay/response.phphttp://localhost/interpos/3d-pay/response.php20220415D7F8810',
+        ]);
+
+        $this->pos->make3DPayment($request);
+        $result = $this->pos->getResponse();
+        $this->assertIsObject($result);
+        $result = (array) $result;
+
+        $this->assertSame('declined', $result['status']);
+        $this->assertSame('81', $result['proc_return_code']);
+        $this->assertSame('B810002', $result['error_code']);
+        $this->assertSame('202204155912', $result['order_id']);
+        $this->assertSame('Auth', $result['transaction']);
+        $this->assertSame('409070******0057', $result['masked_number']);
+        $this->assertSame('30', $result['amount']);
+        $this->assertSame('TRY', $result['currency']);
+        $this->assertSame('klXFUEWTgMc6pRZJFsQRMTOa9us=', $result['hash']);
+        $this->assertSame('Terminal Aktif Degil', $result['error_message']);
+        $this->assertNotEmpty($result['3d_all']);
+        $this->assertNull($result['all']);
     }
 
     /**

--- a/tests/Gateways/InterPosTest.php
+++ b/tests/Gateways/InterPosTest.php
@@ -4,6 +4,7 @@ namespace Mews\Pos\Tests\Gateways;
 
 use GuzzleHttp\Exception\GuzzleException;
 use Mews\Pos\Entity\Account\InterPosAccount;
+use Mews\Pos\Entity\Card\AbstractCreditCard;
 use Mews\Pos\Entity\Card\CreditCardInterPos;
 use Mews\Pos\Factory\AccountFactory;
 use Mews\Pos\Factory\PosFactory;
@@ -54,7 +55,7 @@ class InterPosTest extends TestCase
             InterPos::LANG_TR
         );
 
-        $this->card = new CreditCardInterPos('5555444433332222', '21', '12', '122', 'ahmet', 'visa');
+        $this->card = new CreditCardInterPos('5555444433332222', '21', '12', '122', 'ahmet', AbstractCreditCard::CARD_TYPE_VISA);
 
         $this->order = [
             'id'          => 'order222',
@@ -225,7 +226,7 @@ class InterPosTest extends TestCase
     {
         $order = $this->order;
 
-        $card = new CreditCardInterPos('5555444433332222', '22', '01', '123', 'ahmet', 'visa');
+        $card = new CreditCardInterPos('5555444433332222', '22', '01', '123', 'ahmet', AbstractCreditCard::CARD_TYPE_VISA);
         /** @var InterPos $pos */
         $pos = PosFactory::createPosGateway($this->account);
         $pos->prepare($order, AbstractGateway::TX_PAY, $card);

--- a/tests/Gateways/VakifBankPosTest.php
+++ b/tests/Gateways/VakifBankPosTest.php
@@ -3,6 +3,7 @@
 namespace Mews\Pos\Tests\Gateways;
 
 use Mews\Pos\Entity\Account\VakifBankAccount;
+use Mews\Pos\Entity\Card\AbstractCreditCard;
 use Mews\Pos\Entity\Card\CreditCardVakifBank;
 use Mews\Pos\Factory\AccountFactory;
 use Mews\Pos\Factory\PosFactory;
@@ -50,7 +51,7 @@ class VakifBankPosTest extends TestCase
             AbstractGateway::MODEL_3D_SECURE
         );
 
-        $this->card = new CreditCardVakifBank('5555444433332222', '2021', '12', '122', 'ahmet', 'visa');
+        $this->card = new CreditCardVakifBank('5555444433332222', '2021', '12', '122', 'ahmet', AbstractCreditCard::CARD_TYPE_VISA);
 
         $this->order = [
             'id'          => 'order222',


### PR DESCRIPTION
- added `$request` parameter to **make3DPayment()**, **make3DPayPayment()**, **make3DHostPayment(**) methods to make them more testable
- **send()** method now returns response data instead of _$this_ to make it more testable.
- replaced card types (visa, master) with constants.
- fixed invalid URL in POSNet examples
- added more unit tests for some credit card classes