### PR TITLE
Added additional data into dispatched events

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,26 +257,7 @@ $pos = \Mews\Pos\Factory\PosFactory::createPosGateway(
 
 ## Genel Kultur
 
-### NonSecure, 3D Secure, 3DPay ve 3DHost ödeme modeller arasındaki farklar
-
-- **3DSecure** - Bankaya göre farklı isimler verilebilir, örn. 3D Full.
-  Gateway'den (3D şifre girdiginiz sayfadan) döndükten sonra ödemeyi tamamlamak
-  için
-  banka gateway'ne 1 istek daha (_provizyon_ isteği) gönderir.
-  Bu isteği göndermeden ödeme **tamamlanmaz**.
-- **3DPay** - Bankaya göre farklı isimler verilebilir, örn. 3D Half.
-  Gateway'den (3D şifre girdiginiz sayfadan) döndükten sonra ödeme bitmiş
-  sayılır.
-  3DSecure ödemede yapıldığı gibi ekstra provizyon istek gönderilmez.
-- **3DHost** - Kredi kart girişi için kullanıcı bankanın sayfasına yönledirilir,
-  kredi kart bilgileri girdikten sonra bankanın 3D gateway sayfasına
-  yönlendirilir,
-  ordan da websitenize geri yönlendirilir. Yönlendirme sonucunda ödeme
-  tamanlanmış olur.
-- **NonSecure** - Ödeme işlemi kullanıcı 3D onay işlemi yapmadan gerçekleşir.
-- **NonSecure, 3DSecure ve 3DPay** - Ödemede kredi kart bilgisi websiteniz
-  tarafından alınır.
-  **3DHost** ödemede ise banka websayfasından alınır.
+Ödeme modelleri hakkında bilgi edinmek istiyorsanız [bu makaleyi](https://medium.com/p/fa5cd016999c) inceleyebilirsiniz.
 
 ### Otorizasyon, Ön Otorizasyon, Ön Provizyon Kapama İşlemler arasındaki farklar
 

--- a/docs/PRE-AUTH-POST-EXAMPLE.md
+++ b/docs/PRE-AUTH-POST-EXAMPLE.md
@@ -236,8 +236,8 @@ $order = createPostPayOrder(
 /** @var \Symfony\Component\EventDispatcher\EventDispatcher $eventDispatcher */
 $eventDispatcher->addListener(
     \Mews\Pos\Event\RequestDataPreparedEvent::class,
-    function (\Mews\Pos\Event\RequestDataPreparedEvent $event) use ($gatewayClass, $preAuthAmount, $postAuthAmount) {
-        if (\Mews\Pos\Gateways\EstPos::class === $gatewayClass || \Mews\Pos\Gateways\EstV3Pos::class === $gatewayClass) {
+    function (\Mews\Pos\Event\RequestDataPreparedEvent $event) use ($preAuthAmount, $postAuthAmount) {
+        if (\Mews\Pos\Gateways\EstPos::class === $event->getGatewayClass() || \Mews\Pos\Gateways\EstV3Pos::class === $event->getGatewayClass()) {
             // ($preAuthAmount < $postAuthAmount) durumda API isteğe ekstra değerler eklenmesi gerekiyor.
             if ($preAuthAmount < $postAuthAmount) {
                 $requestData                    = $event->getRequestData();

--- a/docs/THREED-PAYMENT-EXAMPLE.md
+++ b/docs/THREED-PAYMENT-EXAMPLE.md
@@ -150,8 +150,8 @@ try {
      * Bu Event'i dinleyerek 3D formun hash verisi hesaplanmadan önce formun input array içireğini güncelleyebilirsiniz.
      * Eğer ekleyeceğiniz veri hash hesaplamada kullanılmıyorsa Form verisi oluştuktan sonra da güncelleyebilirsiniz.
      */
-    $eventDispatcher->addListener(Before3DFormHashCalculatedEvent::class, function (Before3DFormHashCalculatedEvent $event) use ($pos): void {
-        if (get_class($pos) === \Mews\Pos\Gateways\EstPos::class || get_class($pos) === \Mews\Pos\Gateways\EstV3Pos::class) {
+    $eventDispatcher->addListener(Before3DFormHashCalculatedEvent::class, function (Before3DFormHashCalculatedEvent $event): void {
+        if ($event->getGatewayClass() === \Mews\Pos\Gateways\EstPos::class || $event->getGatewayClass() === \Mews\Pos\Gateways\EstV3Pos::class) {
             /**
              * Örnek 1: İşbank İmece Kart ile ödeme yaparken aşağıdaki verilerin eklenmesi gerekiyor:
                 $supportedPaymentModels = [
@@ -179,8 +179,8 @@ try {
     // KuveytVos TDV2.0.0 icin ozel biri durum
     $eventDispatcher->addListener(
         RequestDataPreparedEvent::class,
-        function (RequestDataPreparedEvent $requestDataPreparedEvent) use ($pos): void {
-            if (get_class($pos) !== \Mews\Pos\Gateways\KuveytPos::class) {
+        function (RequestDataPreparedEvent $requestDataPreparedEvent): void {
+            if ($event->getGatewayClass() !== \Mews\Pos\Gateways\KuveytPos::class) {
                 return;
             }
             // KuveytPos TDV2.0.0 icin zorunlu eklenmesi gereken ekstra alanlar:

--- a/examples/_common-codes/3d/form.php
+++ b/examples/_common-codes/3d/form.php
@@ -69,8 +69,8 @@ if (in_array(get_class($pos), $formVerisiniOlusturmakIcinApiIstegiGonderenGatewa
 // KuveytVos TDV2.0.0 icin ozel biri durum
 $eventDispatcher->addListener(
     RequestDataPreparedEvent::class,
-    function (RequestDataPreparedEvent $requestDataPreparedEvent) use ($pos): void {
-        if (get_class($pos) !== \Mews\Pos\Gateways\KuveytPos::class) {
+    function (RequestDataPreparedEvent $requestDataPreparedEvent): void {
+        if ($requestDataPreparedEvent->getGatewayClass() !== \Mews\Pos\Gateways\KuveytPos::class) {
             return;
         }
         // KuveytPos TDV2.0.0 icin zorunlu eklenmesi gereken ekstra alanlar:
@@ -135,8 +135,8 @@ $eventDispatcher->addListener(
      * Bu Event'i dinleyerek 3D formun hash verisi hesaplanmadan önce formun input array içireğini güncelleyebilirsiniz.
      * Eger ekleyeceginiz veri hash hesaplamada kullanilmiyorsa form verisi olusturduktan sonra da ekleyebilirsiniz.
      */
-    $eventDispatcher->addListener(Before3DFormHashCalculatedEvent::class, function (Before3DFormHashCalculatedEvent $event) use ($pos): void {
-        if (get_class($pos) === \Mews\Pos\Gateways\EstPos::class || get_class($pos) === \Mews\Pos\Gateways\EstV3Pos::class) {
+    $eventDispatcher->addListener(Before3DFormHashCalculatedEvent::class, function (Before3DFormHashCalculatedEvent $event): void {
+        if ($event->getGatewayClass() === \Mews\Pos\Gateways\EstPos::class || $event->getGatewayClass() === \Mews\Pos\Gateways\EstV3Pos::class) {
             //Örnek 1: İşbank İmece Kart ile ödeme yaparken aşağıdaki verilerin eklenmesi gerekiyor:
 //                $supportedPaymentModels = [
 //                    \Mews\Pos\PosInterface::MODEL_3D_PAY,
@@ -150,7 +150,7 @@ $eventDispatcher->addListener(
 //                    $event->setFormInputs($formInputs);
 //                }
         }
-        if (get_class($pos) === \Mews\Pos\Gateways\EstV3Pos::class) {
+        if ($event->getGatewayClass() === \Mews\Pos\Gateways\EstV3Pos::class) {
 //                // Örnek 2: callbackUrl eklenmesi
 //                $formInputs                = $event->getFormInputs();
 //                $formInputs['callbackUrl'] = $formInputs['failUrl'];

--- a/examples/_common-codes/regular/post-auth.php
+++ b/examples/_common-codes/regular/post-auth.php
@@ -46,8 +46,8 @@ $order = createPostPayOrder(
 /** @var \Symfony\Component\EventDispatcher\EventDispatcher $eventDispatcher */
 $eventDispatcher->addListener(
     \Mews\Pos\Event\RequestDataPreparedEvent::class,
-    function (\Mews\Pos\Event\RequestDataPreparedEvent $event) use ($gatewayClass, $preAuthAmount, $postAuthAmount) {
-        if (\Mews\Pos\Gateways\EstPos::class === $gatewayClass || \Mews\Pos\Gateways\EstV3Pos::class === $gatewayClass) {
+    function (\Mews\Pos\Event\RequestDataPreparedEvent $event) use ($preAuthAmount, $postAuthAmount) {
+        if (\Mews\Pos\Gateways\EstPos::class === $event->getGatewayClass() || \Mews\Pos\Gateways\EstV3Pos::class === $event->getGatewayClass()) {
             if ($preAuthAmount < $postAuthAmount) {
                 $requestData                    = $event->getRequestData();
                 $requestData['Extra']['PREAMT'] = $preAuthAmount;

--- a/examples/_templates/_finish_non_secure_payment.php
+++ b/examples/_templates/_finish_non_secure_payment.php
@@ -22,7 +22,7 @@ if (($request->getMethod() !== 'POST')) {
 // OZEL DURUMLAR ICIN KODLAR START
 // ============================================================================================
 /** @var \Symfony\Component\EventDispatcher\EventDispatcher $eventDispatcher */
-$eventDispatcher->addListener(RequestDataPreparedEvent::class, function (RequestDataPreparedEvent $event) use ($pos) {
+$eventDispatcher->addListener(RequestDataPreparedEvent::class, function (RequestDataPreparedEvent $event) {
 //         Burda istek banka API'na gonderilmeden once gonderilecek veriyi degistirebilirsiniz.
 //         Ornek:
 //         $data = $event->getRequestData();
@@ -38,13 +38,13 @@ $eventDispatcher->addListener(RequestDataPreparedEvent::class, function (Request
      * 5: Ekstre Erteleme
      * 6: Özel Vade Farkı
      */
-    if ($pos instanceof \Mews\Pos\Gateways\PosNetV1Pos) {
+    if ($event->getGatewayClass() instanceof \Mews\Pos\Gateways\PosNetV1Pos) {
         // Albaraka PosNet KOICode ekleme
         // $data            = $event->getRequestData();
         // $data['KOICode'] = '1';
         // $event->setRequestData($data);
     }
-    if ($pos instanceof \Mews\Pos\Gateways\PosNet) {
+    if ($event->getGatewayClass() instanceof \Mews\Pos\Gateways\PosNet) {
         // Yapikredi PosNet KOICode ekleme
         // $data            = $event->getRequestData();
         // $data['sale']['koiCode'] = '1';

--- a/examples/_templates/_payment_secure_response.php
+++ b/examples/_templates/_payment_secure_response.php
@@ -36,7 +36,7 @@ if (!$order) {
 // OZEL DURUMLAR ICIN KODLAR START
 // ============================================================================================
 /** @var \Symfony\Component\EventDispatcher\EventDispatcher $eventDispatcher */
-$eventDispatcher->addListener(RequestDataPreparedEvent::class, function (RequestDataPreparedEvent $event) use ($pos) {
+$eventDispatcher->addListener(RequestDataPreparedEvent::class, function (RequestDataPreparedEvent $event) {
 //         Burda istek banka API'na gonderilmeden once gonderilecek veriyi degistirebilirsiniz.
 //         Ornek:
 //         $data = $event->getRequestData();
@@ -56,7 +56,7 @@ $eventDispatcher->addListener(RequestDataPreparedEvent::class, function (Request
      * 5: Ekstre Erteleme
      * 6: Özel Vade Farkı
      */
-    if ($pos instanceof \Mews\Pos\Gateways\PosNetV1Pos && $event->getTxType() === PosInterface::TX_TYPE_PAY_AUTH) {
+    if ($event->getGatewayClass() instanceof \Mews\Pos\Gateways\PosNetV1Pos && $event->getTxType() === PosInterface::TX_TYPE_PAY_AUTH) {
         // Albaraka PosNet KOICode ekleme
         // $data            = $event->getRequestData();
         // $data['KOICode'] = '1';

--- a/src/DataMapper/RequestDataMapper/AkbankPosRequestDataMapper.php
+++ b/src/DataMapper/RequestDataMapper/AkbankPosRequestDataMapper.php
@@ -11,6 +11,7 @@ use Mews\Pos\Entity\Account\AkbankPosAccount;
 use Mews\Pos\Entity\Card\CreditCardInterface;
 use Mews\Pos\Event\Before3DFormHashCalculatedEvent;
 use Mews\Pos\Exceptions\NotImplementedException;
+use Mews\Pos\Gateways\AkbankPos;
 use Mews\Pos\PosInterface;
 
 /**
@@ -394,7 +395,8 @@ class AkbankPosRequestDataMapper extends AbstractRequestDataMapper
             $data['inputs'],
             $posAccount->getBank(),
             $txType,
-            $paymentModel
+            $paymentModel,
+            AkbankPos::class
         );
         $this->eventDispatcher->dispatch($event);
         $data['inputs'] = $event->getFormInputs();

--- a/src/DataMapper/RequestDataMapper/EstPosRequestDataMapper.php
+++ b/src/DataMapper/RequestDataMapper/EstPosRequestDataMapper.php
@@ -10,6 +10,7 @@ use Mews\Pos\Entity\Card\CreditCardInterface;
 use Mews\Pos\Event\Before3DFormHashCalculatedEvent;
 use Mews\Pos\Exceptions\NotImplementedException;
 use Mews\Pos\Exceptions\UnsupportedTransactionTypeException;
+use Mews\Pos\Gateways\EstPos;
 use Mews\Pos\PosInterface;
 
 /**
@@ -243,7 +244,13 @@ class EstPosRequestDataMapper extends AbstractRequestDataMapper
 
         $data = $this->create3DFormDataCommon($posAccount, $preparedOrder, $paymentModel, $txType, $gatewayURL, $creditCard);
 
-        $event = new Before3DFormHashCalculatedEvent($data['inputs'], $posAccount->getBank(), $txType, $paymentModel);
+        $event = new Before3DFormHashCalculatedEvent(
+            $data['inputs'],
+            $posAccount->getBank(),
+            $txType,
+            $paymentModel,
+            EstPos::class
+        );
         $this->eventDispatcher->dispatch($event);
         $data['inputs'] = $event->getFormInputs();
 

--- a/src/DataMapper/RequestDataMapper/EstV3PosRequestDataMapper.php
+++ b/src/DataMapper/RequestDataMapper/EstV3PosRequestDataMapper.php
@@ -7,6 +7,7 @@ namespace Mews\Pos\DataMapper\RequestDataMapper;
 use Mews\Pos\Entity\Account\AbstractPosAccount;
 use Mews\Pos\Entity\Card\CreditCardInterface;
 use Mews\Pos\Event\Before3DFormHashCalculatedEvent;
+use Mews\Pos\Gateways\EstV3Pos;
 
 /**
  * Creates request data for EstPos Gateway requests that supports v3 Hash algorithm
@@ -27,7 +28,13 @@ class EstV3PosRequestDataMapper extends EstPosRequestDataMapper
 
         $data['inputs']['hashAlgorithm'] = 'ver3';
 
-        $event = new Before3DFormHashCalculatedEvent($data['inputs'], $posAccount->getBank(), $txType, $paymentModel);
+        $event = new Before3DFormHashCalculatedEvent(
+            $data['inputs'],
+            $posAccount->getBank(),
+            $txType,
+            $paymentModel,
+            EstV3Pos::class
+        );
         $this->eventDispatcher->dispatch($event);
         $data['inputs'] = $event->getFormInputs();
 

--- a/src/DataMapper/RequestDataMapper/GarantiPosRequestDataMapper.php
+++ b/src/DataMapper/RequestDataMapper/GarantiPosRequestDataMapper.php
@@ -12,6 +12,7 @@ use Mews\Pos\Entity\Account\GarantiPosAccount;
 use Mews\Pos\Entity\Card\CreditCardInterface;
 use Mews\Pos\Event\Before3DFormHashCalculatedEvent;
 use Mews\Pos\Exceptions\NotImplementedException;
+use Mews\Pos\Gateways\GarantiPos;
 use Mews\Pos\PosInterface;
 
 /**
@@ -359,7 +360,13 @@ class GarantiPosRequestDataMapper extends AbstractRequestDataMapper
             $inputs['cardcvv2']            = $creditCard->getCvv();
         }
 
-        $event = new Before3DFormHashCalculatedEvent($inputs, $posAccount->getBank(), $txType, $paymentModel);
+        $event = new Before3DFormHashCalculatedEvent(
+            $inputs,
+            $posAccount->getBank(),
+            $txType,
+            $paymentModel,
+            GarantiPos::class
+        );
         $this->eventDispatcher->dispatch($event);
         $inputs = $event->getFormInputs();
 

--- a/src/DataMapper/RequestDataMapper/InterPosRequestDataMapper.php
+++ b/src/DataMapper/RequestDataMapper/InterPosRequestDataMapper.php
@@ -9,6 +9,7 @@ use Mews\Pos\Entity\Account\AbstractPosAccount;
 use Mews\Pos\Entity\Card\CreditCardInterface;
 use Mews\Pos\Event\Before3DFormHashCalculatedEvent;
 use Mews\Pos\Exceptions\NotImplementedException;
+use Mews\Pos\Gateways\InterPos;
 use Mews\Pos\PosInterface;
 
 /**
@@ -228,7 +229,13 @@ class InterPosRequestDataMapper extends AbstractRequestDataMapper
             $inputs['Cvv2']     = $creditCard->getCvv();
         }
 
-        $event = new Before3DFormHashCalculatedEvent($inputs, $posAccount->getBank(), $txType, $paymentModel);
+        $event = new Before3DFormHashCalculatedEvent(
+            $inputs,
+            $posAccount->getBank(),
+            $txType,
+            $paymentModel,
+            InterPos::class
+        );
         $this->eventDispatcher->dispatch($event);
         $inputs = $event->getFormInputs();
 

--- a/src/DataMapper/RequestDataMapper/PayForPosRequestDataMapper.php
+++ b/src/DataMapper/RequestDataMapper/PayForPosRequestDataMapper.php
@@ -8,6 +8,7 @@ namespace Mews\Pos\DataMapper\RequestDataMapper;
 use Mews\Pos\Entity\Account\AbstractPosAccount;
 use Mews\Pos\Entity\Card\CreditCardInterface;
 use Mews\Pos\Event\Before3DFormHashCalculatedEvent;
+use Mews\Pos\Gateways\PayForPos;
 use Mews\Pos\PosInterface;
 
 /**
@@ -237,7 +238,13 @@ class PayForPosRequestDataMapper extends AbstractRequestDataMapper
             $inputs['Cvv2']           = $creditCard->getCvv();
         }
 
-        $event = new Before3DFormHashCalculatedEvent($inputs, $posAccount->getBank(), $txType, $paymentModel);
+        $event = new Before3DFormHashCalculatedEvent(
+            $inputs,
+            $posAccount->getBank(),
+            $txType,
+            $paymentModel,
+            PayForPos::class
+        );
         $this->eventDispatcher->dispatch($event);
         $inputs = $event->getFormInputs();
 

--- a/src/DataMapper/RequestDataMapper/PosNetV1PosRequestDataMapper.php
+++ b/src/DataMapper/RequestDataMapper/PosNetV1PosRequestDataMapper.php
@@ -12,6 +12,7 @@ use Mews\Pos\Entity\Card\CreditCardInterface;
 use Mews\Pos\Event\Before3DFormHashCalculatedEvent;
 use Mews\Pos\Exceptions\NotImplementedException;
 use Mews\Pos\Exceptions\UnsupportedTransactionTypeException;
+use Mews\Pos\Gateways\PosNetV1Pos;
 use Mews\Pos\PosInterface;
 
 /**
@@ -386,7 +387,13 @@ class PosNetV1PosRequestDataMapper extends AbstractRequestDataMapper
 
         $inputs += $cardData;
 
-        $event = new Before3DFormHashCalculatedEvent($inputs, $posAccount->getBank(), $txType, $paymentModel);
+        $event = new Before3DFormHashCalculatedEvent(
+            $inputs,
+            $posAccount->getBank(),
+            $txType,
+            $paymentModel,
+            PosNetV1Pos::class
+        );
         $this->eventDispatcher->dispatch($event);
         $inputs = $event->getFormInputs();
 

--- a/src/DataMapper/ResponseDataMapper/PosNetResponseDataMapper.php
+++ b/src/DataMapper/ResponseDataMapper/PosNetResponseDataMapper.php
@@ -107,6 +107,7 @@ class PosNetResponseDataMapper extends AbstractResponseDataMapper
             $defaultResponse['proc_return_code'] = $procReturnCode;
             $defaultResponse['error_code']       = $raw3DAuthResponseData['respCode'];
             $defaultResponse['error_message']    = $raw3DAuthResponseData['respText'];
+            $defaultResponse['3d_all']           = $raw3DAuthResponseData;
 
             return $defaultResponse;
         }

--- a/src/Event/Before3DFormHashCalculatedEvent.php
+++ b/src/Event/Before3DFormHashCalculatedEvent.php
@@ -25,21 +25,32 @@ class Before3DFormHashCalculatedEvent
     /** @var PosInterface::MODEL_3D_* */
     private string $paymentModel;
 
+    /** @var class-string<PosInterface> */
+    private string $gatewayClass;
+
     /**
      * @phpstan-param PosInterface::TX_TYPE_PAY_* $txType
      * @phpstan-param PosInterface::MODEL_3D_*    $paymentModel
+     * @phpstan-param class-string<PosInterface>  $gatewayClass
      *
      * @param array<string, string> $formInputs
      * @param string                $bank
      * @param string                $txType
      * @param string                $paymentModel
+     * @param string                $gatewayClass
      */
-    public function __construct(array $formInputs, string $bank, string $txType, string $paymentModel)
-    {
+    public function __construct(
+        array $formInputs,
+        string $bank,
+        string $txType,
+        string $paymentModel,
+        string $gatewayClass
+    ) {
         $this->formInputs   = $formInputs;
         $this->bank         = $bank;
         $this->txType       = $txType;
         $this->paymentModel = $paymentModel;
+        $this->gatewayClass = $gatewayClass;
     }
 
     /**
@@ -84,5 +95,13 @@ class Before3DFormHashCalculatedEvent
         $this->formInputs = $formInputs;
 
         return $this;
+    }
+
+    /**
+     * @return class-string<PosInterface>
+     */
+    public function getGatewayClass(): string
+    {
+        return $this->gatewayClass;
     }
 }

--- a/src/Event/RequestDataPreparedEvent.php
+++ b/src/Event/RequestDataPreparedEvent.php
@@ -16,6 +16,9 @@ class RequestDataPreparedEvent
     /** @var array<string, mixed> */
     private array $requestData;
 
+    /** @var array<string, mixed> */
+    private array $order;
+
     private string $bank;
 
     /** @var PosInterface::TX_TYPE_* */
@@ -32,17 +35,20 @@ class RequestDataPreparedEvent
      * @param string               $bank
      * @param string               $txType
      * @param string               $gatewayClass
+     * @param array<string, mixed> $order
      */
     public function __construct(
         array  $requestData,
         string $bank,
         string $txType,
-        string $gatewayClass
+        string $gatewayClass,
+        array  $order
     ) {
         $this->requestData  = $requestData;
         $this->bank         = $bank;
         $this->txType       = $txType;
         $this->gatewayClass = $gatewayClass;
+        $this->order        = $order;
     }
 
     /**
@@ -63,6 +69,14 @@ class RequestDataPreparedEvent
         $this->requestData = $requestData;
 
         return $this;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getOrder(): array
+    {
+        return $this->order;
     }
 
     /**

--- a/src/Event/RequestDataPreparedEvent.php
+++ b/src/Event/RequestDataPreparedEvent.php
@@ -24,11 +24,15 @@ class RequestDataPreparedEvent
     /** @var PosInterface::TX_TYPE_* */
     private string $txType;
 
+    /** @var PosInterface::MODEL_* */
+    private string $paymentModel;
+
     /** @var class-string<PosInterface> */
     private string $gatewayClass;
 
     /**
      * @phpstan-param PosInterface::TX_TYPE_*    $txType
+     * @phpstan-param PosInterface::MODEL_*      $paymentModel
      * @phpstan-param class-string<PosInterface> $gatewayClass
      *
      * @param array<string, mixed> $requestData
@@ -36,19 +40,22 @@ class RequestDataPreparedEvent
      * @param string               $txType
      * @param string               $gatewayClass
      * @param array<string, mixed> $order
+     * @param string               $paymentModel
      */
     public function __construct(
         array  $requestData,
         string $bank,
         string $txType,
         string $gatewayClass,
-        array  $order
+        array  $order,
+        string $paymentModel
     ) {
         $this->requestData  = $requestData;
         $this->bank         = $bank;
         $this->txType       = $txType;
         $this->gatewayClass = $gatewayClass;
         $this->order        = $order;
+        $this->paymentModel = $paymentModel;
     }
 
     /**
@@ -85,6 +92,14 @@ class RequestDataPreparedEvent
     public function getTxType(): string
     {
         return $this->txType;
+    }
+
+    /**
+     * @return PosInterface::MODEL_*
+     */
+    public function getPaymentModel(): string
+    {
+        return $this->paymentModel;
     }
 
     /**

--- a/src/Event/RequestDataPreparedEvent.php
+++ b/src/Event/RequestDataPreparedEvent.php
@@ -21,21 +21,28 @@ class RequestDataPreparedEvent
     /** @var PosInterface::TX_TYPE_* */
     private string $txType;
 
+    /** @var class-string<PosInterface> */
+    private string $gatewayClass;
+
     /**
-     * @phpstan-param PosInterface::TX_TYPE_* $txType
+     * @phpstan-param PosInterface::TX_TYPE_*    $txType
+     * @phpstan-param class-string<PosInterface> $gatewayClass
      *
      * @param array<string, mixed> $requestData
      * @param string               $bank
      * @param string               $txType
+     * @param string               $gatewayClass
      */
     public function __construct(
         array  $requestData,
         string $bank,
-        string $txType
+        string $txType,
+        string $gatewayClass
     ) {
-        $this->requestData = $requestData;
-        $this->bank        = $bank;
-        $this->txType = $txType;
+        $this->requestData  = $requestData;
+        $this->bank         = $bank;
+        $this->txType       = $txType;
+        $this->gatewayClass = $gatewayClass;
     }
 
     /**
@@ -72,5 +79,13 @@ class RequestDataPreparedEvent
     public function getBank(): string
     {
         return $this->bank;
+    }
+
+    /**
+     * @return class-string<PosInterface>
+     */
+    public function getGatewayClass(): string
+    {
+        return $this->gatewayClass;
     }
 }

--- a/src/Gateways/AbstractGateway.php
+++ b/src/Gateways/AbstractGateway.php
@@ -230,7 +230,12 @@ abstract class AbstractGateway implements PosInterface
             throw new LogicException(\sprintf('Invalid transaction type "%s" provided', $txType));
         }
 
-        $event = new RequestDataPreparedEvent($requestData, $this->account->getBank(), $txType);
+        $event = new RequestDataPreparedEvent(
+            $requestData,
+            $this->account->getBank(),
+            $txType,
+            \get_class($this)
+        );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {
             $this->logger->debug('Request data is changed via listeners', [
@@ -267,7 +272,12 @@ abstract class AbstractGateway implements PosInterface
 
         $requestData = $this->requestDataMapper->createNonSecurePostAuthPaymentRequestData($this->account, $order);
 
-        $event = new RequestDataPreparedEvent($requestData, $this->account->getBank(), $txType);
+        $event = new RequestDataPreparedEvent(
+            $requestData,
+            $this->account->getBank(),
+            $txType,
+            \get_class($this)
+        );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {
             $this->logger->debug('Request data is changed via listeners', [
@@ -299,7 +309,12 @@ abstract class AbstractGateway implements PosInterface
         $txType      = PosInterface::TX_TYPE_REFUND;
         $requestData = $this->requestDataMapper->createRefundRequestData($this->account, $order);
 
-        $event = new RequestDataPreparedEvent($requestData, $this->account->getBank(), $txType);
+        $event = new RequestDataPreparedEvent(
+            $requestData,
+            $this->account->getBank(),
+            $txType,
+            \get_class($this)
+        );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {
             $this->logger->debug('Request data is changed via listeners', [
@@ -335,7 +350,12 @@ abstract class AbstractGateway implements PosInterface
         $txType      = PosInterface::TX_TYPE_CANCEL;
         $requestData = $this->requestDataMapper->createCancelRequestData($this->account, $order);
 
-        $event = new RequestDataPreparedEvent($requestData, $this->account->getBank(), $txType);
+        $event = new RequestDataPreparedEvent(
+            $requestData,
+            $this->account->getBank(),
+            $txType,
+            \get_class($this)
+        );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {
             $this->logger->debug('Request data is changed via listeners', [
@@ -371,7 +391,12 @@ abstract class AbstractGateway implements PosInterface
         $txType      = PosInterface::TX_TYPE_STATUS;
         $requestData = $this->requestDataMapper->createStatusRequestData($this->account, $order);
 
-        $event = new RequestDataPreparedEvent($requestData, $this->account->getBank(), $txType);
+        $event = new RequestDataPreparedEvent(
+            $requestData,
+            $this->account->getBank(),
+            $txType,
+            \get_class($this)
+        );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {
             $this->logger->debug('Request data is changed via listeners', [
@@ -403,7 +428,12 @@ abstract class AbstractGateway implements PosInterface
         $txType      = PosInterface::TX_TYPE_HISTORY;
         $requestData = $this->requestDataMapper->createHistoryRequestData($this->account, $data);
 
-        $event = new RequestDataPreparedEvent($requestData, $this->account->getBank(), $txType);
+        $event = new RequestDataPreparedEvent(
+            $requestData,
+            $this->account->getBank(),
+            $txType,
+            \get_class($this)
+        );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {
             $this->logger->debug('Request data is changed via listeners', [
@@ -435,7 +465,12 @@ abstract class AbstractGateway implements PosInterface
         $txType      = PosInterface::TX_TYPE_ORDER_HISTORY;
         $requestData = $this->requestDataMapper->createOrderHistoryRequestData($this->account, $order);
 
-        $event = new RequestDataPreparedEvent($requestData, $this->account->getBank(), $txType);
+        $event = new RequestDataPreparedEvent(
+            $requestData,
+            $this->account->getBank(),
+            $txType,
+            \get_class($this)
+        );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {
             $this->logger->debug('Request data is changed via listeners', [

--- a/src/Gateways/AbstractGateway.php
+++ b/src/Gateways/AbstractGateway.php
@@ -235,7 +235,8 @@ abstract class AbstractGateway implements PosInterface
             $this->account->getBank(),
             $txType,
             \get_class($this),
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {
@@ -278,7 +279,8 @@ abstract class AbstractGateway implements PosInterface
             $this->account->getBank(),
             $txType,
             \get_class($this),
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {
@@ -316,7 +318,8 @@ abstract class AbstractGateway implements PosInterface
             $this->account->getBank(),
             $txType,
             \get_class($this),
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {
@@ -358,7 +361,8 @@ abstract class AbstractGateway implements PosInterface
             $this->account->getBank(),
             $txType,
             \get_class($this),
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {
@@ -400,7 +404,8 @@ abstract class AbstractGateway implements PosInterface
             $this->account->getBank(),
             $txType,
             \get_class($this),
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {
@@ -438,7 +443,8 @@ abstract class AbstractGateway implements PosInterface
             $this->account->getBank(),
             $txType,
             \get_class($this),
-            $data
+            $data,
+            PosInterface::MODEL_NON_SECURE
         );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {
@@ -476,7 +482,8 @@ abstract class AbstractGateway implements PosInterface
             $this->account->getBank(),
             $txType,
             \get_class($this),
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {

--- a/src/Gateways/AbstractGateway.php
+++ b/src/Gateways/AbstractGateway.php
@@ -234,7 +234,8 @@ abstract class AbstractGateway implements PosInterface
             $requestData,
             $this->account->getBank(),
             $txType,
-            \get_class($this)
+            \get_class($this),
+            $order
         );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {
@@ -276,7 +277,8 @@ abstract class AbstractGateway implements PosInterface
             $requestData,
             $this->account->getBank(),
             $txType,
-            \get_class($this)
+            \get_class($this),
+            $order
         );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {
@@ -313,7 +315,8 @@ abstract class AbstractGateway implements PosInterface
             $requestData,
             $this->account->getBank(),
             $txType,
-            \get_class($this)
+            \get_class($this),
+            $order
         );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {
@@ -354,7 +357,8 @@ abstract class AbstractGateway implements PosInterface
             $requestData,
             $this->account->getBank(),
             $txType,
-            \get_class($this)
+            \get_class($this),
+            $order
         );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {
@@ -395,7 +399,8 @@ abstract class AbstractGateway implements PosInterface
             $requestData,
             $this->account->getBank(),
             $txType,
-            \get_class($this)
+            \get_class($this),
+            $order
         );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {
@@ -432,7 +437,8 @@ abstract class AbstractGateway implements PosInterface
             $requestData,
             $this->account->getBank(),
             $txType,
-            \get_class($this)
+            \get_class($this),
+            $data
         );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {
@@ -469,7 +475,8 @@ abstract class AbstractGateway implements PosInterface
             $requestData,
             $this->account->getBank(),
             $txType,
-            \get_class($this)
+            \get_class($this),
+            $order
         );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {

--- a/src/Gateways/AkbankPos.php
+++ b/src/Gateways/AkbankPos.php
@@ -88,7 +88,8 @@ class AkbankPos extends AbstractGateway
             $requestData,
             $this->account->getBank(),
             $txType,
-            \get_class($this)
+            \get_class($this),
+            $order
         );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {

--- a/src/Gateways/AkbankPos.php
+++ b/src/Gateways/AkbankPos.php
@@ -89,7 +89,8 @@ class AkbankPos extends AbstractGateway
             $this->account->getBank(),
             $txType,
             \get_class($this),
-            $order
+            $order,
+            PosInterface::MODEL_3D_SECURE
         );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {

--- a/src/Gateways/AkbankPos.php
+++ b/src/Gateways/AkbankPos.php
@@ -84,7 +84,12 @@ class AkbankPos extends AbstractGateway
 
         $requestData = $this->requestDataMapper->create3DPaymentRequestData($this->account, $order, $txType, $request->all());
 
-        $event = new RequestDataPreparedEvent($requestData, $this->account->getBank(), $txType);
+        $event = new RequestDataPreparedEvent(
+            $requestData,
+            $this->account->getBank(),
+            $txType,
+            \get_class($this)
+        );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {
             $this->logger->debug('Request data is changed via listeners', [

--- a/src/Gateways/EstPos.php
+++ b/src/Gateways/EstPos.php
@@ -83,7 +83,12 @@ class EstPos extends AbstractGateway
 
         $requestData = $this->requestDataMapper->create3DPaymentRequestData($this->account, $order, $txType, $request->all());
 
-        $event = new RequestDataPreparedEvent($requestData, $this->account->getBank(), $txType);
+        $event = new RequestDataPreparedEvent(
+            $requestData,
+            $this->account->getBank(),
+            $txType,
+            \get_class($this)
+        );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {
             $this->logger->debug('Request data is changed via listeners', [

--- a/src/Gateways/EstPos.php
+++ b/src/Gateways/EstPos.php
@@ -88,7 +88,8 @@ class EstPos extends AbstractGateway
             $this->account->getBank(),
             $txType,
             \get_class($this),
-            $order
+            $order,
+            PosInterface::MODEL_3D_SECURE
         );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {

--- a/src/Gateways/EstPos.php
+++ b/src/Gateways/EstPos.php
@@ -87,7 +87,8 @@ class EstPos extends AbstractGateway
             $requestData,
             $this->account->getBank(),
             $txType,
-            \get_class($this)
+            \get_class($this),
+            $order
         );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {

--- a/src/Gateways/GarantiPos.php
+++ b/src/Gateways/GarantiPos.php
@@ -81,7 +81,8 @@ class GarantiPos extends AbstractGateway
             $requestData,
             $this->account->getBank(),
             $txType,
-            \get_class($this)
+            \get_class($this),
+            $order
         );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {

--- a/src/Gateways/GarantiPos.php
+++ b/src/Gateways/GarantiPos.php
@@ -82,7 +82,8 @@ class GarantiPos extends AbstractGateway
             $this->account->getBank(),
             $txType,
             \get_class($this),
-            $order
+            $order,
+            PosInterface::MODEL_3D_SECURE
         );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {

--- a/src/Gateways/GarantiPos.php
+++ b/src/Gateways/GarantiPos.php
@@ -77,7 +77,12 @@ class GarantiPos extends AbstractGateway
 
         $requestData = $this->requestDataMapper->create3DPaymentRequestData($this->account, $order, $txType, $request->all());
 
-        $event = new RequestDataPreparedEvent($requestData, $this->account->getBank(), $txType);
+        $event = new RequestDataPreparedEvent(
+            $requestData,
+            $this->account->getBank(),
+            $txType,
+            \get_class($this)
+        );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {
             $this->logger->debug('Request data is changed via listeners', [

--- a/src/Gateways/InterPos.php
+++ b/src/Gateways/InterPos.php
@@ -88,7 +88,8 @@ class InterPos extends AbstractGateway
             $this->account->getBank(),
             $txType,
             \get_class($this),
-            $order
+            $order,
+            PosInterface::MODEL_3D_SECURE
         );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {

--- a/src/Gateways/InterPos.php
+++ b/src/Gateways/InterPos.php
@@ -87,7 +87,8 @@ class InterPos extends AbstractGateway
             $requestData,
             $this->account->getBank(),
             $txType,
-            \get_class($this)
+            \get_class($this),
+            $order
         );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {

--- a/src/Gateways/InterPos.php
+++ b/src/Gateways/InterPos.php
@@ -83,7 +83,12 @@ class InterPos extends AbstractGateway
 
         $requestData  = $this->requestDataMapper->create3DPaymentRequestData($this->account, $order, $txType, $gatewayResponse);
 
-        $event = new RequestDataPreparedEvent($requestData, $this->account->getBank(), $txType);
+        $event = new RequestDataPreparedEvent(
+            $requestData,
+            $this->account->getBank(),
+            $txType,
+            \get_class($this)
+        );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {
             $this->logger->debug('Request data is changed via listeners', [

--- a/src/Gateways/KuveytPos.php
+++ b/src/Gateways/KuveytPos.php
@@ -173,7 +173,8 @@ class KuveytPos extends AbstractGateway
             $this->account->getBank(),
             $txType,
             \get_class($this),
-            $order
+            $order,
+            PosInterface::MODEL_3D_SECURE
         );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {
@@ -333,7 +334,8 @@ class KuveytPos extends AbstractGateway
             $this->account->getBank(),
             $txType,
             \get_class($this),
-            $order
+            $order,
+            $paymentModel
         );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {

--- a/src/Gateways/KuveytPos.php
+++ b/src/Gateways/KuveytPos.php
@@ -168,7 +168,12 @@ class KuveytPos extends AbstractGateway
 
         $requestData = $this->requestDataMapper->create3DPaymentRequestData($this->account, $order, $txType, $gatewayResponse);
 
-        $event = new RequestDataPreparedEvent($requestData, $this->account->getBank(), $txType);
+        $event = new RequestDataPreparedEvent(
+            $requestData,
+            $this->account->getBank(),
+            $txType,
+            \get_class($this)
+        );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {
             $this->logger->debug('Request data is changed via listeners', [
@@ -314,9 +319,20 @@ class KuveytPos extends AbstractGateway
      */
     private function getCommon3DFormData(KuveytPosAccount $kuveytPosAccount, array $order, string $paymentModel, string $txType, string $gatewayURL, ?CreditCardInterface $creditCard = null): array
     {
-        $requestData = $this->requestDataMapper->create3DEnrollmentCheckRequestData($kuveytPosAccount, $order, $paymentModel, $txType, $creditCard);
+        $requestData = $this->requestDataMapper->create3DEnrollmentCheckRequestData(
+            $kuveytPosAccount,
+            $order,
+            $paymentModel,
+            $txType,
+            $creditCard
+        );
 
-        $event = new RequestDataPreparedEvent($requestData, $this->account->getBank(), $txType);
+        $event = new RequestDataPreparedEvent(
+            $requestData,
+            $this->account->getBank(),
+            $txType,
+            \get_class($this)
+        );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {
             $this->logger->debug('Request data is changed via listeners', [

--- a/src/Gateways/KuveytPos.php
+++ b/src/Gateways/KuveytPos.php
@@ -172,7 +172,8 @@ class KuveytPos extends AbstractGateway
             $requestData,
             $this->account->getBank(),
             $txType,
-            \get_class($this)
+            \get_class($this),
+            $order
         );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {
@@ -331,7 +332,8 @@ class KuveytPos extends AbstractGateway
             $requestData,
             $this->account->getBank(),
             $txType,
-            \get_class($this)
+            \get_class($this),
+            $order
         );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {

--- a/src/Gateways/PayFlexCPV4Pos.php
+++ b/src/Gateways/PayFlexCPV4Pos.php
@@ -93,7 +93,8 @@ class PayFlexCPV4Pos extends AbstractGateway
             $this->account->getBank(),
             $txType,
             \get_class($this),
-            $order
+            $order,
+            PosInterface::MODEL_3D_PAY
         );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {
@@ -249,7 +250,8 @@ class PayFlexCPV4Pos extends AbstractGateway
             $this->account->getBank(),
             $txType,
             \get_class($this),
-            $order
+            $order,
+            $paymentModel
         );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {

--- a/src/Gateways/PayFlexCPV4Pos.php
+++ b/src/Gateways/PayFlexCPV4Pos.php
@@ -92,7 +92,8 @@ class PayFlexCPV4Pos extends AbstractGateway
             $requestData,
             $this->account->getBank(),
             $txType,
-            \get_class($this)
+            \get_class($this),
+            $order
         );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {
@@ -247,7 +248,8 @@ class PayFlexCPV4Pos extends AbstractGateway
             $requestData,
             $this->account->getBank(),
             $txType,
-            \get_class($this)
+            \get_class($this),
+            $order
         );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {

--- a/src/Gateways/PayFlexCPV4Pos.php
+++ b/src/Gateways/PayFlexCPV4Pos.php
@@ -88,7 +88,12 @@ class PayFlexCPV4Pos extends AbstractGateway
         // Burda odemenin basarili olup olmadigini sorguluyoruz.
         $requestData = $this->requestDataMapper->create3DPaymentStatusRequestData($this->account, $queryParams);
 
-        $event = new RequestDataPreparedEvent($requestData, $this->account->getBank(), PosInterface::TX_TYPE_PAY_AUTH);
+        $event = new RequestDataPreparedEvent(
+            $requestData,
+            $this->account->getBank(),
+            $txType,
+            \get_class($this)
+        );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {
             $this->logger->debug('Request data is changed via listeners', [
@@ -238,7 +243,12 @@ class PayFlexCPV4Pos extends AbstractGateway
             $creditCard
         );
 
-        $event = new RequestDataPreparedEvent($requestData, $this->account->getBank(), $txType);
+        $event = new RequestDataPreparedEvent(
+            $requestData,
+            $this->account->getBank(),
+            $txType,
+            \get_class($this)
+        );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {
             $this->logger->debug('Request data is changed via listeners', [

--- a/src/Gateways/PayFlexV4Pos.php
+++ b/src/Gateways/PayFlexV4Pos.php
@@ -82,7 +82,8 @@ class PayFlexV4Pos extends AbstractGateway
             $requestData,
             $this->account->getBank(),
             $txType,
-            \get_class($this)
+            \get_class($this),
+            $order
         );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {
@@ -222,7 +223,8 @@ class PayFlexV4Pos extends AbstractGateway
             $requestData,
             $this->account->getBank(),
             $txType,
-            \get_class($this)
+            \get_class($this),
+            $order
         );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {

--- a/src/Gateways/PayFlexV4Pos.php
+++ b/src/Gateways/PayFlexV4Pos.php
@@ -83,7 +83,8 @@ class PayFlexV4Pos extends AbstractGateway
             $this->account->getBank(),
             $txType,
             \get_class($this),
-            $order
+            $order,
+            PosInterface::MODEL_3D_SECURE
         );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {
@@ -151,7 +152,7 @@ class PayFlexV4Pos extends AbstractGateway
             throw new LogicException('Kredi kartı bilgileri eksik!');
         }
 
-        $data = $this->sendEnrollmentRequest($order, $creditCard, $txType);
+        $data = $this->sendEnrollmentRequest($order, $creditCard, $txType, $paymentModel);
 
         $status = $data['Message']['VERes']['Status'];
         /**
@@ -206,16 +207,18 @@ class PayFlexV4Pos extends AbstractGateway
      * (Enrollment Status) sorulması, yani kart 3-D Secure programına dâhil mi yoksa değil mi sorgusu
      *
      * @phpstan-param PosInterface::TX_TYPE_PAY_AUTH|PosInterface::TX_TYPE_PAY_PRE_AUTH $txType
+     * @phpstan-param PosInterface::MODEL_3D_*                                          $paymentModel
      *
      * @param array<string, int|string|float|null> $order
      * @param CreditCardInterface                  $creditCard
      * @param string                               $txType
+     * @param string                               $paymentModel
      *
      * @return array<string, mixed>
      *
      * @throws Exception
      */
-    private function sendEnrollmentRequest(array $order, CreditCardInterface $creditCard, string $txType): array
+    private function sendEnrollmentRequest(array $order, CreditCardInterface $creditCard, string $txType, string $paymentModel): array
     {
         $requestData = $this->requestDataMapper->create3DEnrollmentCheckRequestData($this->account, $order, $creditCard);
 
@@ -224,7 +227,8 @@ class PayFlexV4Pos extends AbstractGateway
             $this->account->getBank(),
             $txType,
             \get_class($this),
-            $order
+            $order,
+            $paymentModel
         );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {

--- a/src/Gateways/PayFlexV4Pos.php
+++ b/src/Gateways/PayFlexV4Pos.php
@@ -78,7 +78,12 @@ class PayFlexV4Pos extends AbstractGateway
         // NOT: diger gatewaylerden farkli olarak payflex kredit bilgilerini bu asamada da istiyor.
         $requestData = $this->requestDataMapper->create3DPaymentRequestData($this->account, $order, $txType, $requestData, $creditCard);
 
-        $event = new RequestDataPreparedEvent($requestData, $this->account->getBank(), $txType);
+        $event = new RequestDataPreparedEvent(
+            $requestData,
+            $this->account->getBank(),
+            $txType,
+            \get_class($this)
+        );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {
             $this->logger->debug('Request data is changed via listeners', [
@@ -213,7 +218,12 @@ class PayFlexV4Pos extends AbstractGateway
     {
         $requestData = $this->requestDataMapper->create3DEnrollmentCheckRequestData($this->account, $order, $creditCard);
 
-        $event = new RequestDataPreparedEvent($requestData, $this->account->getBank(), $txType);
+        $event = new RequestDataPreparedEvent(
+            $requestData,
+            $this->account->getBank(),
+            $txType,
+            \get_class($this)
+        );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {
             $this->logger->debug('Request data is changed via listeners', [

--- a/src/Gateways/PayFlexV4Pos.php
+++ b/src/Gateways/PayFlexV4Pos.php
@@ -186,9 +186,10 @@ class PayFlexV4Pos extends AbstractGateway
         $this->logger->debug('sending request', ['url' => $url]);
 
         $isXML = \is_string($contents);
-        $body = $isXML ? ['form_params' => ['prmstr' => $contents]] : ['form_params' => $contents];
 
-        $response = $this->client->post($url, $body);
+        $response = $this->client->post($url, [
+            'form_params' => $isXML ? ['prmstr' => $contents] : $contents,
+        ]);
         $this->logger->debug('request completed', ['status_code' => $response->getStatusCode()]);
 
         return $this->data = $this->serializer->decode($response->getBody()->getContents(), $txType);

--- a/src/Gateways/PayForPos.php
+++ b/src/Gateways/PayForPos.php
@@ -82,7 +82,8 @@ class PayForPos extends AbstractGateway
             $this->account->getBank(),
             $txType,
             \get_class($this),
-            $order
+            $order,
+            PosInterface::MODEL_3D_SECURE
         );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {

--- a/src/Gateways/PayForPos.php
+++ b/src/Gateways/PayForPos.php
@@ -81,7 +81,8 @@ class PayForPos extends AbstractGateway
             $requestData,
             $this->account->getBank(),
             $txType,
-            \get_class($this)
+            \get_class($this),
+            $order
         );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {

--- a/src/Gateways/PayForPos.php
+++ b/src/Gateways/PayForPos.php
@@ -77,7 +77,12 @@ class PayForPos extends AbstractGateway
         // valid ProcReturnCode is V033 in case of success 3D Authentication
         $requestData = $this->requestDataMapper->create3DPaymentRequestData($this->account, $order, $txType, $request->all());
 
-        $event = new RequestDataPreparedEvent($requestData, $this->account->getBank(), $txType);
+        $event = new RequestDataPreparedEvent(
+            $requestData,
+            $this->account->getBank(),
+            $txType,
+            \get_class($this)
+        );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {
             $this->logger->debug('Request data is changed via listeners', [

--- a/src/Gateways/PosNet.php
+++ b/src/Gateways/PosNet.php
@@ -69,7 +69,12 @@ class PosNet extends AbstractGateway
             $request->all()
         );
 
-        $event = new RequestDataPreparedEvent($requestData, $this->account->getBank(), $txType);
+        $event = new RequestDataPreparedEvent(
+            $requestData,
+            $this->account->getBank(),
+            $txType,
+            \get_class($this)
+        );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {
             $this->logger->debug('Request data is changed via listeners', [
@@ -102,7 +107,12 @@ class PosNet extends AbstractGateway
 
         $requestData  = $this->requestDataMapper->create3DPaymentRequestData($this->account, $order, $txType, $request->all());
 
-        $event = new RequestDataPreparedEvent($requestData, $this->account->getBank(), $txType);
+        $event = new RequestDataPreparedEvent(
+            $requestData,
+            $this->account->getBank(),
+            $txType,
+            \get_class($this)
+        );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {
             $this->logger->debug('Request data is changed via listeners', [
@@ -236,7 +246,12 @@ class PosNet extends AbstractGateway
     {
         $requestData = $this->requestDataMapper->create3DEnrollmentCheckRequestData($this->account, $order, $txType, $creditCard);
 
-        $event = new RequestDataPreparedEvent($requestData, $this->account->getBank(), $txType);
+        $event = new RequestDataPreparedEvent(
+            $requestData,
+            $this->account->getBank(),
+            $txType,
+            \get_class($this)
+        );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {
             $this->logger->debug('Request data is changed via listeners', [

--- a/src/Gateways/PosNet.php
+++ b/src/Gateways/PosNet.php
@@ -73,7 +73,8 @@ class PosNet extends AbstractGateway
             $requestData,
             $this->account->getBank(),
             $txType,
-            \get_class($this)
+            \get_class($this),
+            $order
         );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {
@@ -111,7 +112,8 @@ class PosNet extends AbstractGateway
             $requestData,
             $this->account->getBank(),
             $txType,
-            \get_class($this)
+            \get_class($this),
+            $order
         );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {
@@ -250,7 +252,8 @@ class PosNet extends AbstractGateway
             $requestData,
             $this->account->getBank(),
             $txType,
-            \get_class($this)
+            \get_class($this),
+            $order
         );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {

--- a/src/Gateways/PosNet.php
+++ b/src/Gateways/PosNet.php
@@ -74,7 +74,8 @@ class PosNet extends AbstractGateway
             $this->account->getBank(),
             $txType,
             \get_class($this),
-            $order
+            $order,
+            PosInterface::MODEL_3D_SECURE
         );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {
@@ -113,7 +114,8 @@ class PosNet extends AbstractGateway
             $this->account->getBank(),
             $txType,
             \get_class($this),
-            $order
+            $order,
+            PosInterface::MODEL_3D_SECURE
         );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {
@@ -165,7 +167,7 @@ class PosNet extends AbstractGateway
             throw new LogicException('Kredi kartı veya sipariş bilgileri eksik!');
         }
 
-        $data = $this->getOosTransactionData($order, $txType, $creditCard);
+        $data = $this->getOosTransactionData($order, $txType, $paymentModel, $creditCard);
 
         if ($this->responseDataMapper::PROCEDURE_SUCCESS_CODE !== $data['approved']) {
             $this->logger->error('enrollment fail response', $data);
@@ -234,9 +236,11 @@ class PosNet extends AbstractGateway
      * siparis bilgileri ve kart bilgilerinin şifrelendiği adımdır.
      *
      * @phpstan-param PosInterface::TX_TYPE_PAY_AUTH|PosInterface::TX_TYPE_PAY_PRE_AUTH $txType
+     * @phpstan-param PosInterface::MODEL_3D_*                                          $paymentModel
      *
      * @param array<string, int|string|float|null> $order
      * @param string                               $txType
+     * @param string                               $paymentModel
      * @param CreditCardInterface                  $creditCard
      *
      * @return array{approved: string, respCode: string, respText: string, oosRequestDataResponse?: array{data1: string, data2: string, sign: string}}
@@ -244,16 +248,22 @@ class PosNet extends AbstractGateway
      * @throws UnsupportedTransactionTypeException
      * @throws ClientExceptionInterface
      */
-    private function getOosTransactionData(array $order, string $txType, CreditCardInterface $creditCard): array
+    private function getOosTransactionData(array $order, string $txType, string $paymentModel, CreditCardInterface $creditCard): array
     {
-        $requestData = $this->requestDataMapper->create3DEnrollmentCheckRequestData($this->account, $order, $txType, $creditCard);
+        $requestData = $this->requestDataMapper->create3DEnrollmentCheckRequestData(
+            $this->account,
+            $order,
+            $txType,
+            $creditCard
+        );
 
         $event = new RequestDataPreparedEvent(
             $requestData,
             $this->account->getBank(),
             $txType,
             \get_class($this),
-            $order
+            $order,
+            $paymentModel
         );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {

--- a/src/Gateways/PosNetV1Pos.php
+++ b/src/Gateways/PosNetV1Pos.php
@@ -93,7 +93,8 @@ class PosNetV1Pos extends AbstractGateway
             $requestData,
             $this->account->getBank(),
             $txType,
-            \get_class($this)
+            \get_class($this),
+            $order
         );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {

--- a/src/Gateways/PosNetV1Pos.php
+++ b/src/Gateways/PosNetV1Pos.php
@@ -89,7 +89,12 @@ class PosNetV1Pos extends AbstractGateway
 
         $requestData = $this->requestDataMapper->create3DPaymentRequestData($this->account, $order, $txType, $request->all());
 
-        $event = new RequestDataPreparedEvent($requestData, $this->account->getBank(), $txType);
+        $event = new RequestDataPreparedEvent(
+            $requestData,
+            $this->account->getBank(),
+            $txType,
+            \get_class($this)
+        );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {
             $this->logger->debug('Request data is changed via listeners', [

--- a/src/Gateways/PosNetV1Pos.php
+++ b/src/Gateways/PosNetV1Pos.php
@@ -94,7 +94,8 @@ class PosNetV1Pos extends AbstractGateway
             $this->account->getBank(),
             $txType,
             \get_class($this),
-            $order
+            $order,
+            PosInterface::MODEL_3D_SECURE
         );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {

--- a/src/Gateways/ToslaPos.php
+++ b/src/Gateways/ToslaPos.php
@@ -224,7 +224,8 @@ class ToslaPos extends AbstractGateway
             $requestData,
             $this->account->getBank(),
             $txType,
-            \get_class($this)
+            \get_class($this),
+            $order
         );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {

--- a/src/Gateways/ToslaPos.php
+++ b/src/Gateways/ToslaPos.php
@@ -225,7 +225,8 @@ class ToslaPos extends AbstractGateway
             $this->account->getBank(),
             $txType,
             \get_class($this),
-            $order
+            $order,
+            $paymentModel
         );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {

--- a/src/Gateways/ToslaPos.php
+++ b/src/Gateways/ToslaPos.php
@@ -220,7 +220,12 @@ class ToslaPos extends AbstractGateway
             $order
         );
 
-        $event = new RequestDataPreparedEvent($requestData, $this->account->getBank(), $txType);
+        $event = new RequestDataPreparedEvent(
+            $requestData,
+            $this->account->getBank(),
+            $txType,
+            \get_class($this)
+        );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {
             $this->logger->debug('Request data is changed via listeners', [

--- a/src/Gateways/VakifKatilimPos.php
+++ b/src/Gateways/VakifKatilimPos.php
@@ -132,7 +132,8 @@ class VakifKatilimPos extends AbstractGateway
             $this->account->getBank(),
             $txType,
             \get_class($this),
-            $order
+            $order,
+            PosInterface::MODEL_3D_SECURE
         );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {
@@ -204,7 +205,8 @@ class VakifKatilimPos extends AbstractGateway
             $this->account->getBank(),
             $txType,
             \get_class($this),
-            $order
+            $order,
+            $paymentModel
         );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {

--- a/src/Gateways/VakifKatilimPos.php
+++ b/src/Gateways/VakifKatilimPos.php
@@ -127,7 +127,12 @@ class VakifKatilimPos extends AbstractGateway
 
         $requestData = $this->requestDataMapper->create3DPaymentRequestData($this->account, $order, $txType, $gatewayResponse);
 
-        $event = new RequestDataPreparedEvent($requestData, $this->account->getBank(), $txType);
+        $event = new RequestDataPreparedEvent(
+            $requestData,
+            $this->account->getBank(),
+            $txType,
+            \get_class($this)
+        );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {
             $this->logger->debug('Request data is changed via listeners', [
@@ -193,7 +198,12 @@ class VakifKatilimPos extends AbstractGateway
     {
         $requestData = $this->requestDataMapper->create3DEnrollmentCheckRequestData($kuveytPosAccount, $order, $paymentModel, $txType, $creditCard);
 
-        $event = new RequestDataPreparedEvent($requestData, $this->account->getBank(), $txType);
+        $event = new RequestDataPreparedEvent(
+            $requestData,
+            $this->account->getBank(),
+            $txType,
+            \get_class($this)
+        );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {
             $this->logger->debug('Request data is changed via listeners', [

--- a/src/Gateways/VakifKatilimPos.php
+++ b/src/Gateways/VakifKatilimPos.php
@@ -131,7 +131,8 @@ class VakifKatilimPos extends AbstractGateway
             $requestData,
             $this->account->getBank(),
             $txType,
-            \get_class($this)
+            \get_class($this),
+            $order
         );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {
@@ -202,7 +203,8 @@ class VakifKatilimPos extends AbstractGateway
             $requestData,
             $this->account->getBank(),
             $txType,
-            \get_class($this)
+            \get_class($this),
+            $order
         );
         $this->eventDispatcher->dispatch($event);
         if ($requestData !== $event->getRequestData()) {

--- a/tests/Unit/DataMapper/RequestDataMapper/AkbankPosRequestDataMapperTest.php
+++ b/tests/Unit/DataMapper/RequestDataMapper/AkbankPosRequestDataMapperTest.php
@@ -13,6 +13,7 @@ use Mews\Pos\Event\Before3DFormHashCalculatedEvent;
 use Mews\Pos\Exceptions\UnsupportedTransactionTypeException;
 use Mews\Pos\Factory\AccountFactory;
 use Mews\Pos\Factory\CreditCardFactory;
+use Mews\Pos\Gateways\AkbankPos;
 use Mews\Pos\PosInterface;
 use Mews\Pos\Tests\Unit\DataMapper\ResponseDataMapper\AkbankPosResponseDataMapperTest;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -147,7 +148,14 @@ class AkbankPosRequestDataMapperTest extends TestCase
 
         $this->dispatcher->expects(self::once())
             ->method('dispatch')
-            ->with($this->logicalAnd($this->isInstanceOf(Before3DFormHashCalculatedEvent::class)));
+            ->with($this->callback(function ($dispatchedEvent) use ($txType, $paymentModel) {
+                return $dispatchedEvent instanceof Before3DFormHashCalculatedEvent
+                    && AkbankPos::class === $dispatchedEvent->getGatewayClass()
+                    && $txType === $dispatchedEvent->getTxType()
+                    && $paymentModel === $dispatchedEvent->getPaymentModel()
+                    && count($dispatchedEvent->getFormInputs()) > 3
+                    ;
+            }));
 
         $actual = $this->requestDataMapper->create3DFormData(
             $this->account,
@@ -200,11 +208,25 @@ class AkbankPosRequestDataMapperTest extends TestCase
             ->method('generateRandomString')
             ->willReturn('random-123');
 
+        $txType       = PosInterface::TX_TYPE_PAY_AUTH;
+        $paymentModel = PosInterface::MODEL_3D_SECURE;
+
+        $this->dispatcher->expects(self::once())
+            ->method('dispatch')
+            ->with($this->callback(function ($dispatchedEvent) use ($txType, $paymentModel) {
+                return $dispatchedEvent instanceof Before3DFormHashCalculatedEvent
+                    && AkbankPos::class === $dispatchedEvent->getGatewayClass()
+                    && $txType === $dispatchedEvent->getTxType()
+                    && $paymentModel === $dispatchedEvent->getPaymentModel()
+                    && count($dispatchedEvent->getFormInputs()) > 3
+                    ;
+            }));
+
         $actual = $this->requestDataMapper->create3DFormData(
             $this->subMerchantAccount,
             $this->order,
-            PosInterface::MODEL_3D_SECURE,
-            PosInterface::TX_TYPE_PAY_AUTH,
+            $paymentModel,
+            $txType,
             'https://bank.com/pay',
             $card
         );

--- a/tests/Unit/DataMapper/RequestDataMapper/EstPosRequestDataMapperTest.php
+++ b/tests/Unit/DataMapper/RequestDataMapper/EstPosRequestDataMapperTest.php
@@ -14,7 +14,6 @@ use Mews\Pos\Event\Before3DFormHashCalculatedEvent;
 use Mews\Pos\Exceptions\UnsupportedTransactionTypeException;
 use Mews\Pos\Factory\AccountFactory;
 use Mews\Pos\Factory\CreditCardFactory;
-use Mews\Pos\Factory\PosFactory;
 use Mews\Pos\Gateways\EstPos;
 use Mews\Pos\PosInterface;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -44,8 +43,6 @@ class EstPosRequestDataMapperTest extends TestCase
     {
         parent::setUp();
 
-        $config = require __DIR__.'/../../../../config/pos_test.php';
-
         $this->account = AccountFactory::createEstPosAccount(
             'akbank',
             '700655000200',
@@ -67,10 +64,9 @@ class EstPosRequestDataMapperTest extends TestCase
         ];
         $this->dispatcher = $this->createMock(EventDispatcherInterface::class);
         $this->crypt = $this->createMock(CryptInterface::class);
-        $pos = PosFactory::createPosGateway($this->account, $config, $this->dispatcher);
 
         $this->requestDataMapper = new EstPosRequestDataMapper($this->dispatcher, $this->crypt);
-        $this->card              = CreditCardFactory::createForGateway($pos, '5555444433332222', '22', '01', '123', 'ahmet', CreditCardInterface::CARD_TYPE_VISA);
+        $this->card              = CreditCardFactory::create('5555444433332222', '22', '01', '123', 'ahmet', CreditCardInterface::CARD_TYPE_VISA);
     }
 
     /**

--- a/tests/Unit/DataMapper/RequestDataMapper/EstPosRequestDataMapperTest.php
+++ b/tests/Unit/DataMapper/RequestDataMapper/EstPosRequestDataMapperTest.php
@@ -10,10 +10,12 @@ use Mews\Pos\DataMapper\RequestDataMapper\EstPosRequestDataMapper;
 use Mews\Pos\Entity\Account\AbstractPosAccount;
 use Mews\Pos\Entity\Account\EstPosAccount;
 use Mews\Pos\Entity\Card\CreditCardInterface;
+use Mews\Pos\Event\Before3DFormHashCalculatedEvent;
 use Mews\Pos\Exceptions\UnsupportedTransactionTypeException;
 use Mews\Pos\Factory\AccountFactory;
 use Mews\Pos\Factory\CreditCardFactory;
 use Mews\Pos\Factory\PosFactory;
+use Mews\Pos\Gateways\EstPos;
 use Mews\Pos\PosInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -32,6 +34,9 @@ class EstPosRequestDataMapperTest extends TestCase
 
     /** @var CryptInterface & MockObject */
     private CryptInterface $crypt;
+
+    /** @var EventDispatcherInterface & MockObject */
+    private EventDispatcherInterface $dispatcher;
 
     private array $order;
 
@@ -60,11 +65,11 @@ class EstPosRequestDataMapperTest extends TestCase
             'fail_url'    => 'https://domain.com/fail_url',
             'lang'        => PosInterface::LANG_TR,
         ];
-        $dispatcher  = $this->createMock(EventDispatcherInterface::class);
+        $this->dispatcher = $this->createMock(EventDispatcherInterface::class);
         $this->crypt = $this->createMock(CryptInterface::class);
-        $pos         = PosFactory::createPosGateway($this->account, $config, $dispatcher);
+        $pos = PosFactory::createPosGateway($this->account, $config, $this->dispatcher);
 
-        $this->requestDataMapper = new EstPosRequestDataMapper($dispatcher, $this->crypt);
+        $this->requestDataMapper = new EstPosRequestDataMapper($this->dispatcher, $this->crypt);
         $this->card              = CreditCardFactory::createForGateway($pos, '5555444433332222', '22', '01', '123', 'ahmet', CreditCardInterface::CARD_TYPE_VISA);
     }
 
@@ -219,6 +224,17 @@ class EstPosRequestDataMapperTest extends TestCase
         $this->crypt->expects(self::once())
             ->method('generateRandomString')
             ->willReturn($expected['inputs']['rnd']);
+
+        $this->dispatcher->expects(self::once())
+            ->method('dispatch')
+            ->with($this->callback(function ($dispatchedEvent) use ($txType, $paymentModel) {
+                return $dispatchedEvent instanceof Before3DFormHashCalculatedEvent
+                    && EstPos::class === $dispatchedEvent->getGatewayClass()
+                    && $txType === $dispatchedEvent->getTxType()
+                    && $paymentModel === $dispatchedEvent->getPaymentModel()
+                    && count($dispatchedEvent->getFormInputs()) > 3
+                    ;
+            }));
 
         $actual = $this->requestDataMapper->create3DFormData(
             $this->account,

--- a/tests/Unit/DataMapper/RequestDataMapper/EstV3PosRequestDataMapperTest.php
+++ b/tests/Unit/DataMapper/RequestDataMapper/EstV3PosRequestDataMapperTest.php
@@ -12,7 +12,6 @@ use Mews\Pos\Entity\Card\CreditCardInterface;
 use Mews\Pos\Event\Before3DFormHashCalculatedEvent;
 use Mews\Pos\Factory\AccountFactory;
 use Mews\Pos\Factory\CreditCardFactory;
-use Mews\Pos\Factory\PosFactory;
 use Mews\Pos\Gateways\EstV3Pos;
 use Mews\Pos\PosInterface;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -40,8 +39,6 @@ class EstV3PosRequestDataMapperTest extends TestCase
     {
         parent::setUp();
 
-        $config = require __DIR__.'/../../../../config/pos_test.php';
-
         $this->account = AccountFactory::createEstPosAccount(
             'payten_v3_hash',
             '190100000',
@@ -52,11 +49,10 @@ class EstV3PosRequestDataMapperTest extends TestCase
         );
 
         $this->dispatcher = $this->createMock(EventDispatcherInterface::class);
-        $pos              = PosFactory::createPosGateway($this->account, $config, $this->dispatcher);
 
         $this->crypt             = $this->createMock(CryptInterface::class);
         $this->requestDataMapper = new EstV3PosRequestDataMapper($this->dispatcher, $this->crypt);
-        $this->card              = CreditCardFactory::createForGateway($pos, '5555444433332222', '22', '01', '123', 'ahmet', CreditCardInterface::CARD_TYPE_VISA);
+        $this->card              = CreditCardFactory::create('5555444433332222', '22', '01', '123', 'ahmet', CreditCardInterface::CARD_TYPE_VISA);
     }
 
     /**

--- a/tests/Unit/DataMapper/RequestDataMapper/GarantiPosRequestDataMapperTest.php
+++ b/tests/Unit/DataMapper/RequestDataMapper/GarantiPosRequestDataMapperTest.php
@@ -14,7 +14,6 @@ use Mews\Pos\Exceptions\UnsupportedTransactionTypeException;
 use Mews\Pos\Factory\AccountFactory;
 use Mews\Pos\Factory\CreditCardFactory;
 use Mews\Pos\Factory\CryptFactory;
-use Mews\Pos\Factory\PosFactory;
 use Mews\Pos\Gateways\GarantiPos;
 use Mews\Pos\PosInterface;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -35,16 +34,12 @@ class GarantiPosRequestDataMapperTest extends TestCase
 
     private array $order;
 
-    private $config;
-
     /** @var EventDispatcherInterface & MockObject */
     private EventDispatcherInterface $dispatcher;
 
     protected function setUp(): void
     {
         parent::setUp();
-
-        $this->config = require __DIR__.'/../../../../config/pos_test.php';
 
         $this->account = AccountFactory::createGarantiPosAccount(
             'garanti',
@@ -70,13 +65,12 @@ class GarantiPosRequestDataMapperTest extends TestCase
         ];
 
         $this->dispatcher = $this->createMock(EventDispatcherInterface::class);
-        $pos              = PosFactory::createPosGateway($this->account, $this->config, $this->dispatcher);
 
         $crypt                   = CryptFactory::createGatewayCrypt(GarantiPos::class, new NullLogger());
         $this->requestDataMapper = new GarantiPosRequestDataMapper($this->dispatcher, $crypt);
         $this->requestDataMapper->setTestMode(true);
 
-        $this->card = CreditCardFactory::createForGateway($pos, '5555444433332222', '22', '01', '123', 'ahmet');
+        $this->card = CreditCardFactory::create('5555444433332222', '22', '01', '123', 'ahmet');
     }
 
     /**
@@ -212,7 +206,7 @@ class GarantiPosRequestDataMapperTest extends TestCase
     public function testGet3DFormData(): void
     {
         $account    = $this->account;
-        $gatewayURL = $this->config['banks'][$this->account->getBank()]['gateway_endpoints']['gateway_3d'];
+        $gatewayURL = 'https://sanalposprovtest.garantibbva.com.tr/servlet/gt3dengine';
         $inputs     = [
             'secure3dsecuritylevel' => '3D',
             'mode'                  => 'TEST',

--- a/tests/Unit/DataMapper/RequestDataMapper/InterPosRequestDataMapperTest.php
+++ b/tests/Unit/DataMapper/RequestDataMapper/InterPosRequestDataMapperTest.php
@@ -13,7 +13,6 @@ use Mews\Pos\Event\Before3DFormHashCalculatedEvent;
 use Mews\Pos\Exceptions\UnsupportedTransactionTypeException;
 use Mews\Pos\Factory\AccountFactory;
 use Mews\Pos\Factory\CreditCardFactory;
-use Mews\Pos\Factory\PosFactory;
 use Mews\Pos\Gateways\InterPos;
 use Mews\Pos\PosInterface;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -43,8 +42,6 @@ class InterPosRequestDataMapperTest extends TestCase
     {
         parent::setUp();
 
-        $config = require __DIR__.'/../../../../config/pos_test.php';
-
         $userCode     = 'InterTestApi';
         $userPass     = '3';
         $shopCode     = '3123';
@@ -70,12 +67,11 @@ class InterPosRequestDataMapperTest extends TestCase
         ];
 
         $this->dispatcher = $this->createMock(EventDispatcherInterface::class);
-        $pos              = PosFactory::createPosGateway($this->account, $config, $this->dispatcher);
 
         $this->crypt             = $this->createMock(CryptInterface::class);
         $this->requestDataMapper = new InterPosRequestDataMapper($this->dispatcher, $this->crypt);
 
-        $this->card = CreditCardFactory::createForGateway($pos, '5555444433332222', '21', '12', '122', 'ahmet', CreditCardInterface::CARD_TYPE_VISA);
+        $this->card = CreditCardFactory::create('5555444433332222', '21', '12', '122', 'ahmet', CreditCardInterface::CARD_TYPE_VISA);
     }
 
     /**

--- a/tests/Unit/DataMapper/RequestDataMapper/KuveytPosRequestDataMapperTest.php
+++ b/tests/Unit/DataMapper/RequestDataMapper/KuveytPosRequestDataMapperTest.php
@@ -33,6 +33,9 @@ class KuveytPosRequestDataMapperTest extends TestCase
     /** @var CryptInterface|MockObject */
     private CryptInterface $crypt;
 
+    /** @var EventDispatcherInterface & MockObject */
+    private EventDispatcherInterface $dispatcher;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -45,7 +48,7 @@ class KuveytPosRequestDataMapperTest extends TestCase
             'Api123'
         );
 
-        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $this->dispatcher = $this->createMock(EventDispatcherInterface::class);
 
         $this->card = CreditCardFactory::create(
             '4155650100416111',
@@ -57,7 +60,7 @@ class KuveytPosRequestDataMapperTest extends TestCase
         );
 
         $this->crypt             = $this->createMock(CryptInterface::class);
-        $this->requestDataMapper = new KuveytPosRequestDataMapper($dispatcher, $this->crypt);
+        $this->requestDataMapper = new KuveytPosRequestDataMapper($this->dispatcher, $this->crypt);
     }
 
     /**
@@ -290,11 +293,16 @@ class KuveytPosRequestDataMapperTest extends TestCase
             ],
         ];
 
+        $txType       = PosInterface::TX_TYPE_PAY_AUTH;
+        $paymentModel = PosInterface::MODEL_3D_SECURE;
+        $this->dispatcher->expects(self::never())
+            ->method('dispatch');
+
         $actual = $this->requestDataMapper->create3DFormData(
             $this->account,
             ['abc' => '123'],
-            PosInterface::MODEL_3D_SECURE,
-            PosInterface::TX_TYPE_PAY_AUTH,
+            $paymentModel,
+            $txType,
             'https://bank-gateway.com',
         );
 

--- a/tests/Unit/DataMapper/RequestDataMapper/PayFlexCPV4PosRequestDataMapperTest.php
+++ b/tests/Unit/DataMapper/RequestDataMapper/PayFlexCPV4PosRequestDataMapperTest.php
@@ -17,6 +17,7 @@ use Mews\Pos\Factory\CryptFactory;
 use Mews\Pos\Factory\PosFactory;
 use Mews\Pos\Gateways\PayFlexCPV4Pos;
 use Mews\Pos\PosInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\NullLogger;
@@ -31,6 +32,9 @@ class PayFlexCPV4PosRequestDataMapperTest extends TestCase
 
     private PayFlexCPV4PosRequestDataMapper $requestDataMapper;
 
+    /** @var EventDispatcherInterface & MockObject */
+    private EventDispatcherInterface $dispatcher;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -43,8 +47,9 @@ class PayFlexCPV4PosRequestDataMapperTest extends TestCase
             PosInterface::MODEL_3D_SECURE
         );
 
+        $this->dispatcher        = $this->createMock(EventDispatcherInterface::class);
         $crypt                   = CryptFactory::createGatewayCrypt(PayFlexCPV4Pos::class, new NullLogger());
-        $this->requestDataMapper = new PayFlexCPV4PosRequestDataMapper($this->createMock(EventDispatcherInterface::class), $crypt);
+        $this->requestDataMapper = new PayFlexCPV4PosRequestDataMapper($this->dispatcher, $crypt);
     }
 
     /**
@@ -140,6 +145,9 @@ class PayFlexCPV4PosRequestDataMapperTest extends TestCase
      */
     public function testCreate3DFormData(array $queryParams, array $expected): void
     {
+        $this->dispatcher->expects(self::never())
+            ->method('dispatch');
+
         $actualData = $this->requestDataMapper->create3DFormData(
             null,
             null,

--- a/tests/Unit/DataMapper/RequestDataMapper/PayFlexCPV4PosRequestDataMapperTest.php
+++ b/tests/Unit/DataMapper/RequestDataMapper/PayFlexCPV4PosRequestDataMapperTest.php
@@ -14,14 +14,12 @@ use Mews\Pos\Exceptions\UnsupportedTransactionTypeException;
 use Mews\Pos\Factory\AccountFactory;
 use Mews\Pos\Factory\CreditCardFactory;
 use Mews\Pos\Factory\CryptFactory;
-use Mews\Pos\Factory\PosFactory;
 use Mews\Pos\Gateways\PayFlexCPV4Pos;
 use Mews\Pos\PosInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\NullLogger;
-use Symfony\Component\EventDispatcher\EventDispatcher;
 
 /**
  * @covers \Mews\Pos\DataMapper\RequestDataMapper\PayFlexCPV4PosRequestDataMapper
@@ -183,10 +181,7 @@ class PayFlexCPV4PosRequestDataMapperTest extends TestCase
             'ip'          => '127.0.0.1',
         ];
 
-        $pos = PosFactory::createPosGateway($account, $config, new EventDispatcher());
-        $pos->setTestMode(true);
-
-        $card = CreditCardFactory::createForGateway($pos, '5555444433332222', '2021', '12', '122', 'ahmet', CreditCardInterface::CARD_TYPE_VISA);
+        $card = CreditCardFactory::create('5555444433332222', '2021', '12', '122', 'ahmet', CreditCardInterface::CARD_TYPE_VISA);
 
         yield 'with_card_1' => [
             'account'  => $account,

--- a/tests/Unit/DataMapper/RequestDataMapper/PayFlexV4PosRequestDataMapperTest.php
+++ b/tests/Unit/DataMapper/RequestDataMapper/PayFlexV4PosRequestDataMapperTest.php
@@ -34,6 +34,9 @@ class PayFlexV4PosRequestDataMapperTest extends TestCase
     /** @var CryptInterface & MockObject */
     private CryptInterface $crypt;
 
+    /** @var EventDispatcherInterface & MockObject */
+    private EventDispatcherInterface $dispatcher;
+
     private array $order;
 
     protected function setUp(): void
@@ -61,11 +64,11 @@ class PayFlexV4PosRequestDataMapperTest extends TestCase
             'ip'          => '127.0.0.1',
         ];
 
-        $dispatcher = $this->createMock(EventDispatcherInterface::class);
-        $pos        = PosFactory::createPosGateway($this->account, $config, $dispatcher);
+        $this->dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $pos              = PosFactory::createPosGateway($this->account, $config, $this->dispatcher);
 
         $this->crypt             = $this->createMock(CryptInterface::class);
-        $this->requestDataMapper = new PayFlexV4PosRequestDataMapper($dispatcher, $this->crypt);
+        $this->requestDataMapper = new PayFlexV4PosRequestDataMapper($this->dispatcher, $this->crypt);
         $this->card              = CreditCardFactory::createForGateway($pos, '5555444433332222', '2021', '12', '122', 'ahmet', CreditCardInterface::CARD_TYPE_VISA);
     }
 
@@ -232,6 +235,10 @@ class PayFlexV4PosRequestDataMapperTest extends TestCase
     public function testCreate3DFormData(): void
     {
         $expectedValue = $this->getSample3DFormDataFromEnrollmentResponse();
+
+        $this->dispatcher->expects(self::never())
+            ->method('dispatch');
+
         $actualData    = $this->requestDataMapper->create3DFormData(
             null,
             null,

--- a/tests/Unit/DataMapper/RequestDataMapper/PayFlexV4PosRequestDataMapperTest.php
+++ b/tests/Unit/DataMapper/RequestDataMapper/PayFlexV4PosRequestDataMapperTest.php
@@ -14,7 +14,6 @@ use Mews\Pos\Entity\Card\CreditCardInterface;
 use Mews\Pos\Exceptions\UnsupportedTransactionTypeException;
 use Mews\Pos\Factory\AccountFactory;
 use Mews\Pos\Factory\CreditCardFactory;
-use Mews\Pos\Factory\PosFactory;
 use Mews\Pos\PosInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -43,8 +42,6 @@ class PayFlexV4PosRequestDataMapperTest extends TestCase
     {
         parent::setUp();
 
-        $config = require __DIR__.'/../../../../config/pos_test.php';
-
         $this->account = AccountFactory::createPayFlexAccount(
             'vakifbank',
             '000000000111111',
@@ -65,11 +62,10 @@ class PayFlexV4PosRequestDataMapperTest extends TestCase
         ];
 
         $this->dispatcher = $this->createMock(EventDispatcherInterface::class);
-        $pos              = PosFactory::createPosGateway($this->account, $config, $this->dispatcher);
 
         $this->crypt             = $this->createMock(CryptInterface::class);
         $this->requestDataMapper = new PayFlexV4PosRequestDataMapper($this->dispatcher, $this->crypt);
-        $this->card              = CreditCardFactory::createForGateway($pos, '5555444433332222', '2021', '12', '122', 'ahmet', CreditCardInterface::CARD_TYPE_VISA);
+        $this->card              = CreditCardFactory::create('5555444433332222', '2021', '12', '122', 'ahmet', CreditCardInterface::CARD_TYPE_VISA);
     }
 
     /**

--- a/tests/Unit/DataMapper/RequestDataMapper/PayForPosRequestDataMapperTest.php
+++ b/tests/Unit/DataMapper/RequestDataMapper/PayForPosRequestDataMapperTest.php
@@ -14,7 +14,6 @@ use Mews\Pos\Event\Before3DFormHashCalculatedEvent;
 use Mews\Pos\Exceptions\UnsupportedTransactionTypeException;
 use Mews\Pos\Factory\AccountFactory;
 use Mews\Pos\Factory\CreditCardFactory;
-use Mews\Pos\Factory\PosFactory;
 use Mews\Pos\Gateways\PayForPos;
 use Mews\Pos\PosInterface;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -37,16 +36,12 @@ class PayForPosRequestDataMapperTest extends TestCase
 
     private array $order;
 
-    private array $config;
-
     /** @var EventDispatcherInterface & MockObject */
     private EventDispatcherInterface $dispatcher;
 
     protected function setUp(): void
     {
         parent::setUp();
-
-        $this->config = require __DIR__.'/../../../../config/pos_test.php';
 
         $this->account = AccountFactory::createPayForAccount(
             'qnbfinansbank-payfor',
@@ -69,10 +64,9 @@ class PayForPosRequestDataMapperTest extends TestCase
 
         $this->crypt      = $this->createMock(CryptInterface::class);
         $this->dispatcher = $this->createMock(EventDispatcherInterface::class);
-        $pos              = PosFactory::createPosGateway($this->account, $this->config, $this->dispatcher);
 
         $this->requestDataMapper = new PayForPosRequestDataMapper($this->dispatcher, $this->crypt);
-        $this->card              = CreditCardFactory::createForGateway($pos, '5555444433332222', '22', '01', '123', 'ahmet');
+        $this->card              = CreditCardFactory::create('5555444433332222', '22', '01', '123', 'ahmet');
     }
 
     /**

--- a/tests/Unit/DataMapper/RequestDataMapper/PosNetRequestDataMapperTest.php
+++ b/tests/Unit/DataMapper/RequestDataMapper/PosNetRequestDataMapperTest.php
@@ -13,7 +13,6 @@ use Mews\Pos\Exceptions\UnsupportedTransactionTypeException;
 use Mews\Pos\Factory\AccountFactory;
 use Mews\Pos\Factory\CreditCardFactory;
 use Mews\Pos\Factory\CryptFactory;
-use Mews\Pos\Factory\PosFactory;
 use Mews\Pos\Gateways\PosNet;
 use Mews\Pos\PosInterface;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -41,8 +40,6 @@ class PosNetRequestDataMapperTest extends TestCase
     {
         parent::setUp();
 
-        $config = require __DIR__.'/../../../../config/pos_test.php';
-
         $this->account = AccountFactory::createPosNetAccount(
             'yapikredi',
             '6706598320',
@@ -63,10 +60,9 @@ class PosNetRequestDataMapperTest extends TestCase
         ];
 
         $this->dispatcher        = $this->createMock(EventDispatcherInterface::class);
-        $pos                     = PosFactory::createPosGateway($this->account, $config, $this->dispatcher);
         $crypt                   = CryptFactory::createGatewayCrypt(PosNet::class, new NullLogger());
         $this->requestDataMapper = new PosNetRequestDataMapper($this->dispatcher, $crypt);
-        $this->card              = CreditCardFactory::createForGateway($pos, '5555444433332222', '22', '01', '123', 'ahmet');
+        $this->card              = CreditCardFactory::create('5555444433332222', '22', '01', '123', 'ahmet');
     }
 
     /**

--- a/tests/Unit/DataMapper/RequestDataMapper/PosNetV1PosRequestDataMapperTest.php
+++ b/tests/Unit/DataMapper/RequestDataMapper/PosNetV1PosRequestDataMapperTest.php
@@ -14,7 +14,6 @@ use Mews\Pos\Exceptions\UnsupportedTransactionTypeException;
 use Mews\Pos\Factory\AccountFactory;
 use Mews\Pos\Factory\CreditCardFactory;
 use Mews\Pos\Factory\CryptFactory;
-use Mews\Pos\Factory\PosFactory;
 use Mews\Pos\Gateways\PosNetV1Pos;
 use Mews\Pos\PosInterface;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -40,8 +39,6 @@ class PosNetV1PosRequestDataMapperTest extends TestCase
     {
         parent::setUp();
 
-        $config = require __DIR__.'/../../../../config/pos_test.php';
-
         $this->account = AccountFactory::createPosNetAccount(
             'albaraka',
             '6700950031',
@@ -52,9 +49,8 @@ class PosNetV1PosRequestDataMapperTest extends TestCase
         );
 
         $this->dispatcher = $this->createMock(EventDispatcherInterface::class);
-        $pos              = PosFactory::createPosGateway($this->account, $config, $this->dispatcher);
 
-        $this->card = CreditCardFactory::createForGateway($pos, '5400619360964581', '20', '01', '056', 'ahmet');
+        $this->card = CreditCardFactory::create('5400619360964581', '20', '01', '056', 'ahmet');
 
         $crypt                   = CryptFactory::createGatewayCrypt(PosNetV1Pos::class, new NullLogger());
         $this->requestDataMapper = new PosNetV1PosRequestDataMapper($this->dispatcher, $crypt);

--- a/tests/Unit/DataMapper/RequestDataMapper/ToslaPosRequestDataMapperTest.php
+++ b/tests/Unit/DataMapper/RequestDataMapper/ToslaPosRequestDataMapperTest.php
@@ -30,6 +30,9 @@ class ToslaPosRequestDataMapperTest extends TestCase
     /** @var CryptInterface & MockObject */
     private CryptInterface $crypt;
 
+    /** @var EventDispatcherInterface & MockObject */
+    private EventDispatcherInterface $dispatcher;
+
     private ToslaPosRequestDataMapper $requestDataMapper;
 
     protected function setUp(): void
@@ -45,11 +48,11 @@ class ToslaPosRequestDataMapperTest extends TestCase
             'POS_ENT_Test_001!*!*',
         );
 
-        $dispatcher = $this->createMock(EventDispatcherInterface::class);
-        $pos        = PosFactory::createPosGateway($this->account, $config, $dispatcher);
+        $this->dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $pos              = PosFactory::createPosGateway($this->account, $config, $this->dispatcher);
 
         $this->crypt             = $this->createMock(CryptInterface::class);
-        $this->requestDataMapper = new ToslaPosRequestDataMapper($dispatcher, $this->crypt);
+        $this->requestDataMapper = new ToslaPosRequestDataMapper($this->dispatcher, $this->crypt);
         $this->card              = CreditCardFactory::createForGateway($pos, '5555444433332222', '22', '01', '123', 'ahmet', CreditCardInterface::CARD_TYPE_VISA);
     }
 
@@ -199,6 +202,9 @@ class ToslaPosRequestDataMapperTest extends TestCase
 
         $this->crypt->expects(self::never())
             ->method('generateRandomString');
+
+        $this->dispatcher->expects(self::never())
+            ->method('dispatch');
 
         $actual = $this->requestDataMapper->create3DFormData(
             $this->account,

--- a/tests/Unit/DataMapper/RequestDataMapper/ToslaPosRequestDataMapperTest.php
+++ b/tests/Unit/DataMapper/RequestDataMapper/ToslaPosRequestDataMapperTest.php
@@ -12,7 +12,6 @@ use Mews\Pos\Entity\Card\CreditCardInterface;
 use Mews\Pos\Exceptions\UnsupportedTransactionTypeException;
 use Mews\Pos\Factory\AccountFactory;
 use Mews\Pos\Factory\CreditCardFactory;
-use Mews\Pos\Factory\PosFactory;
 use Mews\Pos\PosInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -39,8 +38,6 @@ class ToslaPosRequestDataMapperTest extends TestCase
     {
         parent::setUp();
 
-        $config = require __DIR__.'/../../../../config/pos_test.php';
-
         $this->account = AccountFactory::createToslaPosAccount(
             'tosla',
             '1000000494',
@@ -49,11 +46,10 @@ class ToslaPosRequestDataMapperTest extends TestCase
         );
 
         $this->dispatcher = $this->createMock(EventDispatcherInterface::class);
-        $pos              = PosFactory::createPosGateway($this->account, $config, $this->dispatcher);
 
         $this->crypt             = $this->createMock(CryptInterface::class);
         $this->requestDataMapper = new ToslaPosRequestDataMapper($this->dispatcher, $this->crypt);
-        $this->card              = CreditCardFactory::createForGateway($pos, '5555444433332222', '22', '01', '123', 'ahmet', CreditCardInterface::CARD_TYPE_VISA);
+        $this->card              = CreditCardFactory::create('5555444433332222', '22', '01', '123', 'ahmet', CreditCardInterface::CARD_TYPE_VISA);
     }
 
     /**

--- a/tests/Unit/DataMapper/RequestDataMapper/VakifKatilimPosRequestDataMapperTest.php
+++ b/tests/Unit/DataMapper/RequestDataMapper/VakifKatilimPosRequestDataMapperTest.php
@@ -15,6 +15,7 @@ use Mews\Pos\Factory\CreditCardFactory;
 use Mews\Pos\Factory\CryptFactory;
 use Mews\Pos\Gateways\VakifKatilimPos;
 use Mews\Pos\PosInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\NullLogger;
@@ -30,6 +31,9 @@ class VakifKatilimPosRequestDataMapperTest extends TestCase
 
     private VakifKatilimPosRequestDataMapper $requestDataMapper;
 
+    /** @var EventDispatcherInterface & MockObject */
+    private EventDispatcherInterface $dispatcher;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -42,7 +46,7 @@ class VakifKatilimPosRequestDataMapperTest extends TestCase
             'kdsnsksl',
         );
 
-        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $this->dispatcher = $this->createMock(EventDispatcherInterface::class);
 
         $this->card = CreditCardFactory::create(
             '4155650100416111',
@@ -53,7 +57,7 @@ class VakifKatilimPosRequestDataMapperTest extends TestCase
         );
 
         $crypt                   = CryptFactory::createGatewayCrypt(VakifKatilimPos::class, new NullLogger());
-        $this->requestDataMapper = new VakifKatilimPosRequestDataMapper($dispatcher, $crypt);
+        $this->requestDataMapper = new VakifKatilimPosRequestDataMapper($this->dispatcher, $crypt);
     }
 
     /**

--- a/tests/Unit/DataMapper/ResponseDataMapper/PosNetResponseDataMapperTest.php
+++ b/tests/Unit/DataMapper/ResponseDataMapper/PosNetResponseDataMapperTest.php
@@ -98,6 +98,10 @@ class PosNetResponseDataMapperTest extends TestCase
         }
 
         unset($actualData['transaction_time'], $expectedData['transaction_time']);
+
+        $this->assertArrayHasKey('3d_all', $actualData);
+        $this->assertIsArray($actualData['3d_all']);
+        $this->assertNotEmpty($actualData['3d_all']);
         unset($actualData['all'], $actualData['3d_all']);
         \ksort($expectedData);
         \ksort($actualData);

--- a/tests/Unit/Gateways/AkbankPosTest.php
+++ b/tests/Unit/Gateways/AkbankPosTest.php
@@ -298,7 +298,8 @@ class AkbankPosTest extends TestCase
                 'request-body',
                 'response-body',
                 $paymentResponse,
-                $order
+                $order,
+                PosInterface::MODEL_3D_SECURE
             );
 
             $this->responseMapperMock->expects(self::once())
@@ -407,7 +408,8 @@ class AkbankPosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -451,7 +453,8 @@ class AkbankPosTest extends TestCase
             $encodedRequest,
             $responseContent,
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->pos->orderHistory($order);
@@ -481,7 +484,8 @@ class AkbankPosTest extends TestCase
             'request-body',
             $apiUrl,
             ['paymentResponse'],
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -513,6 +517,7 @@ class AkbankPosTest extends TestCase
             $apiUrl,
             ['code' => 123, 'message' => 'error'],
             $order,
+            PosInterface::MODEL_NON_SECURE,
             400
         );
 
@@ -541,7 +546,8 @@ class AkbankPosTest extends TestCase
             'request-body',
             $apiUrl,
             ['paymentResponse'],
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -579,7 +585,8 @@ class AkbankPosTest extends TestCase
             'request-body',
             $apiUrl,
             ['decodedResponse'],
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -611,7 +618,8 @@ class AkbankPosTest extends TestCase
             'request-body',
             $apiUrl,
             ['decodedResponse'],
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -860,6 +868,7 @@ class AkbankPosTest extends TestCase
         string $responseContent,
         array  $decodedResponse,
         array  $order,
+        string $paymentModel,
         ?int   $statusCode = null
     ): void
     {
@@ -894,12 +903,13 @@ class AkbankPosTest extends TestCase
 
         $this->eventDispatcherMock->expects(self::once())
             ->method('dispatch')
-            ->with($this->callback(function ($dispatchedEvent) use ($txType, $requestData, $order) {
+            ->with($this->callback(function ($dispatchedEvent) use ($txType, $requestData, $order, $paymentModel) {
                 return $dispatchedEvent instanceof RequestDataPreparedEvent
                     && get_class($this->pos) === $dispatchedEvent->getGatewayClass()
                     && $txType === $dispatchedEvent->getTxType()
                     && $requestData === $dispatchedEvent->getRequestData()
                     && $order === $dispatchedEvent->getOrder()
+                    && $paymentModel === $dispatchedEvent->getPaymentModel()
                     ;
             }));
     }

--- a/tests/Unit/Gateways/EstPosTest.php
+++ b/tests/Unit/Gateways/EstPosTest.php
@@ -27,8 +27,7 @@ use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @covers \Mews\Pos\Gateways\EstPos
- *
- * @uses \Mews\Pos\Gateways\AbstractGateway
+ * @covers  \Mews\Pos\Gateways\AbstractGateway
  */
 class EstPosTest extends TestCase
 {
@@ -238,38 +237,31 @@ class EstPosTest extends TestCase
      */
     public function testStatus(array $bankResponse, array $expectedData, bool $isSuccess): void
     {
-        $statusRequestData = [
-            'statusRequestData',
-        ];
+        $account     = $this->pos->getAccount();
+        $txType      = PosInterface::TX_TYPE_STATUS;
+        $requestData = ['createStatusRequestData'];
+        $order       = $this->order;
+
         $this->requestMapperMock->expects(self::once())
             ->method('createStatusRequestData')
-            ->willReturn($statusRequestData);
+            ->with($account, $order)
+            ->willReturn($requestData);
 
-        $this->prepareClient(
-            $this->httpClientMock,
-            'response-body',
+        $this->configureClientResponse(
+            $txType,
             'https://entegrasyon.asseco-see.com.tr/fim/api',
-            [
-                'body' => 'request-body',
-            ],
+            $requestData,
+            'request-body',
+            'response-body',
+            $bankResponse,
         );
-
-        $this->serializerMock->expects(self::once())
-            ->method('encode')
-            ->with($statusRequestData, PosInterface::TX_TYPE_STATUS)
-            ->willReturn('request-body');
-
-        $this->serializerMock->expects(self::once())
-            ->method('decode')
-            ->with('response-body', PosInterface::TX_TYPE_STATUS)
-            ->willReturn($bankResponse);
 
         $this->responseMapperMock->expects(self::once())
             ->method('mapStatusResponse')
             ->with($bankResponse)
             ->willReturn($expectedData);
 
-        $this->pos->status($this->order);
+        $this->pos->status($order);
 
         $result = $this->pos->getResponse();
         $this->assertSame($expectedData, $result);
@@ -287,39 +279,31 @@ class EstPosTest extends TestCase
      */
     public function testOrderHistory(array $bankResponse, array $expectedData, bool $isSuccess): void
     {
-        $historyRequestData = [
-            'historyRequestData',
-        ];
+        $account     = $this->pos->getAccount();
+        $txType      = PosInterface::TX_TYPE_ORDER_HISTORY;
+        $requestData = ['createOrderHistoryRequestData'];
+        $order       = $this->order;
+
         $this->requestMapperMock->expects(self::once())
             ->method('createOrderHistoryRequestData')
-            ->willReturn($historyRequestData);
+            ->with($account, $order)
+            ->willReturn($requestData);
 
-        $this->prepareClient(
-            $this->httpClientMock,
-            'response-body',
+        $this->configureClientResponse(
+            $txType,
             'https://entegrasyon.asseco-see.com.tr/fim/api',
-            [
-                'body' => 'request-body',
-            ],
+            $requestData,
+            'request-body',
+            'response-body',
+            $bankResponse,
         );
-
-        $this->serializerMock->expects(self::once())
-            ->method('encode')
-            ->with($historyRequestData, PosInterface::TX_TYPE_ORDER_HISTORY)
-            ->willReturn('request-body');
-
-        $this->serializerMock->expects(self::once())
-            ->method('decode')
-            ->with('response-body', PosInterface::TX_TYPE_ORDER_HISTORY)
-            ->willReturn($bankResponse);
 
         $this->responseMapperMock->expects(self::once())
             ->method('mapOrderHistoryResponse')
             ->with($bankResponse)
             ->willReturn($expectedData);
 
-
-        $this->pos->orderHistory($this->order);
+        $this->pos->orderHistory($order);
 
         $result = $this->pos->getResponse();
         $this->assertSame($expectedData, $result);
@@ -331,38 +315,31 @@ class EstPosTest extends TestCase
      */
     public function testCancel(array $bankResponse, array $expectedData, bool $isSuccess): void
     {
-        $cancelRequestData = [
-            'cancelRequestData',
-        ];
+        $account     = $this->pos->getAccount();
+        $txType      = PosInterface::TX_TYPE_CANCEL;
+        $requestData = ['createCancelRequestData'];
+        $order       = $this->order;
+
         $this->requestMapperMock->expects(self::once())
             ->method('createCancelRequestData')
-            ->willReturn($cancelRequestData);
+            ->with($account, $order)
+            ->willReturn($requestData);
 
-        $this->prepareClient(
-            $this->httpClientMock,
-            'response-body',
+        $this->configureClientResponse(
+            $txType,
             'https://entegrasyon.asseco-see.com.tr/fim/api',
-            [
-                'body' => 'request-body',
-            ],
+            $requestData,
+            'request-body',
+            'response-body',
+            $bankResponse,
         );
-
-        $this->serializerMock->expects(self::once())
-            ->method('encode')
-            ->with($cancelRequestData, PosInterface::TX_TYPE_CANCEL)
-            ->willReturn('request-body');
-
-        $this->serializerMock->expects(self::once())
-            ->method('decode')
-            ->with('response-body', PosInterface::TX_TYPE_CANCEL)
-            ->willReturn($bankResponse);
 
         $this->responseMapperMock->expects(self::once())
             ->method('mapCancelResponse')
             ->with($bankResponse)
             ->willReturn($expectedData);
 
-        $this->pos->cancel($this->order);
+        $this->pos->cancel($order);
 
         $result = $this->pos->getResponse();
         $this->assertSame($expectedData, $result);
@@ -374,38 +351,31 @@ class EstPosTest extends TestCase
      */
     public function testRefund(array $bankResponse, array $expectedData, bool $isSuccess): void
     {
-        $refundRequestData = [
-            'refundRequestData',
-        ];
+        $account     = $this->pos->getAccount();
+        $txType      = PosInterface::TX_TYPE_REFUND;
+        $requestData = ['createRefundRequestData'];
+        $order       = $this->order;
+
         $this->requestMapperMock->expects(self::once())
             ->method('createRefundRequestData')
-            ->willReturn($refundRequestData);
+            ->with($account, $order)
+            ->willReturn($requestData);
 
-        $this->prepareClient(
-            $this->httpClientMock,
-            'response-body',
+        $this->configureClientResponse(
+            $txType,
             'https://entegrasyon.asseco-see.com.tr/fim/api',
-            [
-                'body' => 'request-body',
-            ],
+            $requestData,
+            'request-body',
+            'response-body',
+            $bankResponse,
         );
-
-        $this->serializerMock->expects(self::once())
-            ->method('encode')
-            ->with($refundRequestData, PosInterface::TX_TYPE_REFUND)
-            ->willReturn('request-body');
-
-        $this->serializerMock->expects(self::once())
-            ->method('decode')
-            ->with('response-body', PosInterface::TX_TYPE_REFUND)
-            ->willReturn($bankResponse);
 
         $this->responseMapperMock->expects(self::once())
             ->method('mapRefundResponse')
             ->with($bankResponse)
             ->willReturn($expectedData);
 
-        $this->pos->refund($this->order);
+        $this->pos->refund($order);
 
         $result = $this->pos->getResponse();
         $this->assertSame($expectedData, $result);
@@ -450,23 +420,15 @@ class EstPosTest extends TestCase
                 ->method('create3DPaymentRequestData')
                 ->with($this->account, $order, $txType, $request->request->all())
                 ->willReturn($create3DPaymentRequestData);
-            $this->prepareClient(
-                $this->httpClientMock,
-                'response-body',
-                $this->config['gateway_endpoints']['payment_api'],
-                [
-                    'body' => 'request-body',
-                ],
-            );
 
-            $this->serializerMock->expects(self::once())
-                ->method('encode')
-                ->with($create3DPaymentRequestData, $txType)
-                ->willReturn('request-body');
-            $this->serializerMock->expects(self::once())
-                ->method('decode')
-                ->with('response-body', $txType)
-                ->willReturn($paymentResponse);
+            $this->configureClientResponse(
+                $txType,
+                'https://entegrasyon.asseco-see.com.tr/fim/api',
+                $create3DPaymentRequestData,
+                'request-body',
+                'response-body',
+                $paymentResponse,
+            );
 
             $this->responseMapperMock->expects(self::once())
                 ->method('map3DPaymentData')
@@ -483,6 +445,8 @@ class EstPosTest extends TestCase
                 ->method('encode');
             $this->serializerMock->expects(self::never())
                 ->method('decode');
+            $this->eventDispatcherMock->expects(self::never())
+                ->method('dispatch');
         }
 
         $this->pos->make3DPayment($request, $order, $txType);
@@ -497,34 +461,27 @@ class EstPosTest extends TestCase
      */
     public function testMakeRegularPayment(array $order, string $txType, string $apiUrl): void
     {
-        $account = $this->pos->getAccount();
-        $card    = $this->card;
+        $account     = $this->pos->getAccount();
+        $card        = $this->card;
+        $requestData = ['createNonSecurePaymentRequestData'];
         $this->requestMapperMock->expects(self::once())
             ->method('createNonSecurePaymentRequestData')
             ->with($account, $order, $txType, $card)
-            ->willReturn(['createNonSecurePaymentRequestData']);
-        $this->prepareClient(
-            $this->httpClientMock,
-            'response-body',
+            ->willReturn($requestData);
+
+        $decodedResponse = ['paymentResponse'];
+        $this->configureClientResponse(
+            $txType,
             $apiUrl,
-            [
-                'body'    => 'request-body',
-            ]
+            $requestData,
+            'request-body',
+            'response-body',
+            $decodedResponse,
         );
-
-        $this->serializerMock->expects(self::once())
-            ->method('encode')
-            ->with(['createNonSecurePaymentRequestData'], $txType)
-            ->willReturn('request-body');
-
-        $this->serializerMock->expects(self::once())
-            ->method('decode')
-            ->with('response-body', $txType)
-            ->willReturn(['paymentResponse']);
 
         $this->responseMapperMock->expects(self::once())
             ->method('mapPaymentResponse')
-            ->with(['paymentResponse'], $txType, $order)
+            ->with($decodedResponse, $txType, $order)
             ->willReturn(['result']);
 
         $this->pos->makeRegularPayment($order, $card, $txType);
@@ -535,32 +492,24 @@ class EstPosTest extends TestCase
      */
     public function testMakeRegularPostAuthPayment(array $order, string $apiUrl): void
     {
-        $account = $this->pos->getAccount();
-        $txType  = PosInterface::TX_TYPE_PAY_POST_AUTH;
+        $account     = $this->pos->getAccount();
+        $txType      = PosInterface::TX_TYPE_PAY_POST_AUTH;
+        $requestData = ['createNonSecurePostAuthPaymentRequestData'];
 
         $this->requestMapperMock->expects(self::once())
             ->method('createNonSecurePostAuthPaymentRequestData')
             ->with($account, $order)
-            ->willReturn(['createNonSecurePostAuthPaymentRequestData']);
+            ->willReturn($requestData);
 
-        $this->serializerMock->expects(self::once())
-            ->method('encode')
-            ->with(['createNonSecurePostAuthPaymentRequestData'], $txType)
-            ->willReturn('request-body');
-
-        $this->prepareClient(
-            $this->httpClientMock,
-            'response-body',
+        $decodedResponse = ['paymentResponse'];
+        $this->configureClientResponse(
+            $txType,
             $apiUrl,
-            [
-                'body'    => 'request-body',
-            ]
+            $requestData,
+            'request-body',
+            'response-body',
+            $decodedResponse,
         );
-
-        $this->serializerMock->expects(self::once())
-            ->method('decode')
-            ->with('response-body', $txType)
-            ->willReturn(['paymentResponse']);
 
         $this->responseMapperMock->expects(self::once())
             ->method('mapPaymentResponse')
@@ -726,39 +675,32 @@ class EstPosTest extends TestCase
         ];
     }
 
-    public static function refundRequestDataProvider(): array
+    private function configureClientResponse(
+        string $txType,
+        string $apiUrl,
+        array  $requestData,
+        string $encodedRequestData,
+        string $responseContent,
+        array  $decodedResponse
+    ): void
     {
-        return [
-            [
-                'order'   => [
-                    'id' => '2020110828BC',
-                ],
-                'api_url' => 'https://sanalposprovtest.garantibbva.com.tr/VPServlet',
-            ],
-        ];
-    }
+        $this->serializerMock->expects(self::once())
+            ->method('encode')
+            ->with($requestData, $txType)
+            ->willReturn($encodedRequestData);
 
-    public static function historyRequestDataProvider(): array
-    {
-        return [
-            [
-                'order'   => [
-                    'id' => '2020110828BC',
-                ],
-                'api_url' => 'https://sanalposprovtest.garantibbva.com.tr/VPServlet',
-            ],
-        ];
-    }
+        $this->serializerMock->expects(self::once())
+            ->method('decode')
+            ->with($responseContent, $txType)
+            ->willReturn($decodedResponse);
 
-    public static function orderHistoryRequestDataProvider(): array
-    {
-        return [
+        $this->prepareClient(
+            $this->httpClientMock,
+            $responseContent,
+            $apiUrl,
             [
-                'order'   => [
-                    'id' => '2020110828BC',
-                ],
-                'api_url' => 'https://sanalposprovtest.garantibbva.com.tr/VPServlet',
+                'body' => $encodedRequestData,
             ],
-        ];
+        );
     }
 }

--- a/tests/Unit/Gateways/EstPosTest.php
+++ b/tests/Unit/Gateways/EstPosTest.php
@@ -255,6 +255,7 @@ class EstPosTest extends TestCase
             'request-body',
             'response-body',
             $bankResponse,
+            $order
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -297,6 +298,7 @@ class EstPosTest extends TestCase
             'request-body',
             'response-body',
             $bankResponse,
+            $order
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -333,6 +335,7 @@ class EstPosTest extends TestCase
             'request-body',
             'response-body',
             $bankResponse,
+            $order
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -369,6 +372,7 @@ class EstPosTest extends TestCase
             'request-body',
             'response-body',
             $bankResponse,
+            $order
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -429,6 +433,7 @@ class EstPosTest extends TestCase
                 'request-body',
                 'response-body',
                 $paymentResponse,
+                $order
             );
 
             $this->responseMapperMock->expects(self::once())
@@ -478,6 +483,7 @@ class EstPosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
+            $order
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -510,6 +516,7 @@ class EstPosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
+            $order
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -682,7 +689,8 @@ class EstPosTest extends TestCase
         array  $requestData,
         string $encodedRequestData,
         string $responseContent,
-        array  $decodedResponse
+        array  $decodedResponse,
+        array  $order
     ): void
     {
         $this->serializerMock->expects(self::once())
@@ -706,11 +714,12 @@ class EstPosTest extends TestCase
 
         $this->eventDispatcherMock->expects(self::once())
             ->method('dispatch')
-            ->with($this->callback(function ($dispatchedEvent) use ($txType, $requestData) {
+            ->with($this->callback(function ($dispatchedEvent) use ($txType, $requestData, $order) {
                 return $dispatchedEvent instanceof RequestDataPreparedEvent
                     && get_class($this->pos) === $dispatchedEvent->getGatewayClass()
                     && $txType === $dispatchedEvent->getTxType()
                     && $requestData === $dispatchedEvent->getRequestData()
+                    && $order === $dispatchedEvent->getOrder()
                     ;
             }));
     }

--- a/tests/Unit/Gateways/EstPosTest.php
+++ b/tests/Unit/Gateways/EstPosTest.php
@@ -11,6 +11,7 @@ use Mews\Pos\DataMapper\RequestDataMapper\RequestDataMapperInterface;
 use Mews\Pos\DataMapper\ResponseDataMapper\ResponseDataMapperInterface;
 use Mews\Pos\Entity\Account\EstPosAccount;
 use Mews\Pos\Entity\Card\CreditCardInterface;
+use Mews\Pos\Event\RequestDataPreparedEvent;
 use Mews\Pos\Exceptions\UnsupportedTransactionTypeException;
 use Mews\Pos\Factory\AccountFactory;
 use Mews\Pos\Factory\CreditCardFactory;
@@ -702,5 +703,15 @@ class EstPosTest extends TestCase
                 'body' => $encodedRequestData,
             ],
         );
+
+        $this->eventDispatcherMock->expects(self::once())
+            ->method('dispatch')
+            ->with($this->callback(function ($dispatchedEvent) use ($txType, $requestData) {
+                return $dispatchedEvent instanceof RequestDataPreparedEvent
+                    && get_class($this->pos) === $dispatchedEvent->getGatewayClass()
+                    && $txType === $dispatchedEvent->getTxType()
+                    && $requestData === $dispatchedEvent->getRequestData()
+                    ;
+            }));
     }
 }

--- a/tests/Unit/Gateways/EstPosTest.php
+++ b/tests/Unit/Gateways/EstPosTest.php
@@ -255,7 +255,8 @@ class EstPosTest extends TestCase
             'request-body',
             'response-body',
             $bankResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -298,7 +299,8 @@ class EstPosTest extends TestCase
             'request-body',
             'response-body',
             $bankResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -335,7 +337,8 @@ class EstPosTest extends TestCase
             'request-body',
             'response-body',
             $bankResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -372,7 +375,8 @@ class EstPosTest extends TestCase
             'request-body',
             'response-body',
             $bankResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -433,7 +437,8 @@ class EstPosTest extends TestCase
                 'request-body',
                 'response-body',
                 $paymentResponse,
-                $order
+                $order,
+                PosInterface::MODEL_3D_SECURE
             );
 
             $this->responseMapperMock->expects(self::once())
@@ -483,7 +488,8 @@ class EstPosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -516,7 +522,8 @@ class EstPosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -690,7 +697,8 @@ class EstPosTest extends TestCase
         string $encodedRequestData,
         string $responseContent,
         array  $decodedResponse,
-        array  $order
+        array  $order,
+        string $paymentModel
     ): void
     {
         $this->serializerMock->expects(self::once())
@@ -714,12 +722,13 @@ class EstPosTest extends TestCase
 
         $this->eventDispatcherMock->expects(self::once())
             ->method('dispatch')
-            ->with($this->callback(function ($dispatchedEvent) use ($txType, $requestData, $order) {
+            ->with($this->callback(function ($dispatchedEvent) use ($txType, $requestData, $order, $paymentModel) {
                 return $dispatchedEvent instanceof RequestDataPreparedEvent
                     && get_class($this->pos) === $dispatchedEvent->getGatewayClass()
                     && $txType === $dispatchedEvent->getTxType()
                     && $requestData === $dispatchedEvent->getRequestData()
                     && $order === $dispatchedEvent->getOrder()
+                    && $paymentModel === $dispatchedEvent->getPaymentModel()
                     ;
             }));
     }

--- a/tests/Unit/Gateways/GarantiPosTest.php
+++ b/tests/Unit/Gateways/GarantiPosTest.php
@@ -215,6 +215,7 @@ class GarantiPosTest extends TestCase
                 'request-body',
                 'response-body',
                 $paymentResponse,
+                $order
             );
 
             $this->responseMapperMock->expects(self::once())
@@ -300,6 +301,7 @@ class GarantiPosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
+            $order
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -331,6 +333,7 @@ class GarantiPosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
+            $order
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -363,6 +366,7 @@ class GarantiPosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
+            $order
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -395,6 +399,7 @@ class GarantiPosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
+            $order
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -427,6 +432,7 @@ class GarantiPosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
+            $order
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -465,6 +471,7 @@ class GarantiPosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
+            $order
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -585,7 +592,8 @@ class GarantiPosTest extends TestCase
         array  $requestData,
         string $encodedRequestData,
         string $responseContent,
-        array  $decodedResponse
+        array  $decodedResponse,
+        array  $order
     ): void
     {
         $this->serializerMock->expects(self::once())
@@ -609,11 +617,12 @@ class GarantiPosTest extends TestCase
 
         $this->eventDispatcherMock->expects(self::once())
             ->method('dispatch')
-            ->with($this->callback(function ($dispatchedEvent) use ($txType, $requestData) {
+            ->with($this->callback(function ($dispatchedEvent) use ($txType, $requestData, $order) {
                 return $dispatchedEvent instanceof RequestDataPreparedEvent
                     && get_class($this->pos) === $dispatchedEvent->getGatewayClass()
                     && $txType === $dispatchedEvent->getTxType()
                     && $requestData === $dispatchedEvent->getRequestData()
+                    && $order === $dispatchedEvent->getOrder()
                     ;
             }));
     }

--- a/tests/Unit/Gateways/GarantiPosTest.php
+++ b/tests/Unit/Gateways/GarantiPosTest.php
@@ -11,6 +11,7 @@ use Mews\Pos\DataMapper\RequestDataMapper\RequestDataMapperInterface;
 use Mews\Pos\DataMapper\ResponseDataMapper\ResponseDataMapperInterface;
 use Mews\Pos\Entity\Account\GarantiPosAccount;
 use Mews\Pos\Entity\Card\CreditCardInterface;
+use Mews\Pos\Event\RequestDataPreparedEvent;
 use Mews\Pos\Exceptions\UnsupportedPaymentModelException;
 use Mews\Pos\Exceptions\UnsupportedTransactionTypeException;
 use Mews\Pos\Factory\AccountFactory;
@@ -605,5 +606,15 @@ class GarantiPosTest extends TestCase
                 'body' => $encodedRequestData,
             ],
         );
+
+        $this->eventDispatcherMock->expects(self::once())
+            ->method('dispatch')
+            ->with($this->callback(function ($dispatchedEvent) use ($txType, $requestData) {
+                return $dispatchedEvent instanceof RequestDataPreparedEvent
+                    && get_class($this->pos) === $dispatchedEvent->getGatewayClass()
+                    && $txType === $dispatchedEvent->getTxType()
+                    && $requestData === $dispatchedEvent->getRequestData()
+                    ;
+            }));
     }
 }

--- a/tests/Unit/Gateways/GarantiPosTest.php
+++ b/tests/Unit/Gateways/GarantiPosTest.php
@@ -28,8 +28,7 @@ use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @covers \Mews\Pos\Gateways\GarantiPos
- *
- * @uses  \Mews\Pos\Gateways\AbstractGateway
+ * @covers  \Mews\Pos\Gateways\AbstractGateway
  */
 class GarantiPosTest extends TestCase
 {
@@ -207,23 +206,15 @@ class GarantiPosTest extends TestCase
                 ->method('create3DPaymentRequestData')
                 ->with($this->account, $order, $txType, $request->request->all())
                 ->willReturn($create3DPaymentRequestData);
-            $this->prepareClient(
-                $this->httpClientMock,
-                'response-body',
-                $this->config['gateway_endpoints']['payment_api'],
-                [
-                    'body' => 'request-body',
-                ],
-            );
 
-            $this->serializerMock->expects(self::once())
-                ->method('encode')
-                ->with($create3DPaymentRequestData, $txType)
-                ->willReturn('request-body');
-            $this->serializerMock->expects(self::once())
-                ->method('decode')
-                ->with('response-body', $txType)
-                ->willReturn($paymentResponse);
+            $this->configureClientResponse(
+                $txType,
+                $this->config['gateway_endpoints']['payment_api'],
+                $create3DPaymentRequestData,
+                'request-body',
+                'response-body',
+                $paymentResponse,
+            );
 
             $this->responseMapperMock->expects(self::once())
                 ->method('map3DPaymentData')
@@ -240,6 +231,8 @@ class GarantiPosTest extends TestCase
                 ->method('encode');
             $this->serializerMock->expects(self::never())
                 ->method('decode');
+            $this->eventDispatcherMock->expects(self::never())
+                ->method('dispatch');
         }
 
         $this->pos->make3DPayment($request, $order, $txType);
@@ -289,34 +282,28 @@ class GarantiPosTest extends TestCase
      */
     public function testMakeRegularPayment(array $order, string $txType, string $apiUrl): void
     {
-        $account = $this->pos->getAccount();
-        $card    = $this->card;
+        $account     = $this->pos->getAccount();
+        $card        = $this->card;
+        $requestData = ['createNonSecurePaymentRequestData'];
+
         $this->requestMapperMock->expects(self::once())
             ->method('createNonSecurePaymentRequestData')
             ->with($account, $order, $txType, $card)
-            ->willReturn(['createNonSecurePaymentRequestData']);
-        $this->prepareClient(
-            $this->httpClientMock,
-            'response-body',
+            ->willReturn($requestData);
+
+        $decodedResponse = ['paymentResponse'];
+        $this->configureClientResponse(
+            $txType,
             $apiUrl,
-            [
-                'body'    => 'request-body',
-            ]
+            $requestData,
+            'request-body',
+            'response-body',
+            $decodedResponse,
         );
-
-        $this->serializerMock->expects(self::once())
-            ->method('encode')
-            ->with(['createNonSecurePaymentRequestData'], $txType)
-            ->willReturn('request-body');
-
-        $this->serializerMock->expects(self::once())
-            ->method('decode')
-            ->with('response-body', $txType)
-            ->willReturn(['paymentResponse']);
 
         $this->responseMapperMock->expects(self::once())
             ->method('mapPaymentResponse')
-            ->with(['paymentResponse'], $txType, $order)
+            ->with($decodedResponse, $txType, $order)
             ->willReturn(['result']);
 
         $this->pos->makeRegularPayment($order, $card, $txType);
@@ -327,36 +314,27 @@ class GarantiPosTest extends TestCase
      */
     public function testMakeRegularPostAuthPayment(array $order, string $apiUrl): void
     {
-        $account = $this->pos->getAccount();
-        $txType  = PosInterface::TX_TYPE_PAY_POST_AUTH;
-
+        $account     = $this->pos->getAccount();
+        $txType      = PosInterface::TX_TYPE_PAY_POST_AUTH;
+        $requestData = ['createNonSecurePostAuthPaymentRequestData'];
         $this->requestMapperMock->expects(self::once())
             ->method('createNonSecurePostAuthPaymentRequestData')
             ->with($account, $order)
-            ->willReturn(['createNonSecurePostAuthPaymentRequestData']);
+            ->willReturn($requestData);
 
-        $this->serializerMock->expects(self::once())
-            ->method('encode')
-            ->with(['createNonSecurePostAuthPaymentRequestData'], $txType)
-            ->willReturn('request-body');
-
-        $this->prepareClient(
-            $this->httpClientMock,
-            'response-body',
+        $decodedResponse = ['decodedData'];
+        $this->configureClientResponse(
+            $txType,
             $apiUrl,
-            [
-                'body'    => 'request-body',
-            ]
+            $requestData,
+            'request-body',
+            'response-body',
+            $decodedResponse,
         );
-
-        $this->serializerMock->expects(self::once())
-            ->method('decode')
-            ->with('response-body', $txType)
-            ->willReturn(['paymentResponse']);
 
         $this->responseMapperMock->expects(self::once())
             ->method('mapPaymentResponse')
-            ->with(['paymentResponse'], $txType, $order)
+            ->with($decodedResponse, $txType, $order)
             ->willReturn(['result']);
 
         $this->pos->makeRegularPostPayment($order);
@@ -367,37 +345,28 @@ class GarantiPosTest extends TestCase
      */
     public function testStatusRequest(array $order, string $apiUrl): void
     {
-        $account = $this->pos->getAccount();
-        $txType = PosInterface::TX_TYPE_STATUS;
+        $account     = $this->pos->getAccount();
+        $txType      = PosInterface::TX_TYPE_STATUS;
+        $requestData = ['createStatusRequestData'];
 
         $this->requestMapperMock->expects(self::once())
             ->method('createStatusRequestData')
             ->with($account, $order)
-            ->willReturn(['createStatusRequestData']);
+            ->willReturn($requestData);
 
-        $this->serializerMock->expects(self::once())
-            ->method('encode')
-            ->with(['createStatusRequestData'], $txType)
-            ->willReturn('request-body');
-
-        $this->prepareClient(
-            $this->httpClientMock,
-            'response-body',
+        $decodedResponse = ['decodedData'];
+        $this->configureClientResponse(
+            $txType,
             $apiUrl,
-            [
-                'body'    => 'request-body',
-            ]
+            $requestData,
+            'request-body',
+            'response-body',
+            $decodedResponse,
         );
-
-
-        $this->serializerMock->expects(self::once())
-            ->method('decode')
-            ->with('response-body', $txType)
-            ->willReturn(['decodedResponse']);
 
         $this->responseMapperMock->expects(self::once())
             ->method('mapStatusResponse')
-            ->with(['decodedResponse'])
+            ->with($decodedResponse)
             ->willReturn(['result']);
 
         $this->pos->status($order);
@@ -408,36 +377,28 @@ class GarantiPosTest extends TestCase
      */
     public function testCancelRequest(array $order, string $apiUrl): void
     {
-        $account = $this->pos->getAccount();
-        $txType = PosInterface::TX_TYPE_CANCEL;
+        $account     = $this->pos->getAccount();
+        $txType      = PosInterface::TX_TYPE_CANCEL;
+        $requestData = ['createCancelRequestData'];
 
         $this->requestMapperMock->expects(self::once())
             ->method('createCancelRequestData')
             ->with($account, $order)
-            ->willReturn(['createCancelRequestData']);
+            ->willReturn($requestData);
 
-        $this->serializerMock->expects(self::once())
-            ->method('encode')
-            ->with(['createCancelRequestData'], $txType)
-            ->willReturn('request-body');
-
-        $this->prepareClient(
-            $this->httpClientMock,
-            'response-body',
+        $decodedResponse = ['decodedData'];
+        $this->configureClientResponse(
+            $txType,
             $apiUrl,
-            [
-                'body'    => 'request-body',
-            ]
+            $requestData,
+            'request-body',
+            'response-body',
+            $decodedResponse,
         );
-
-        $this->serializerMock->expects(self::once())
-            ->method('decode')
-            ->with('response-body', $txType)
-            ->willReturn(['decodedResponse']);
 
         $this->responseMapperMock->expects(self::once())
             ->method('mapCancelResponse')
-            ->with(['decodedResponse'])
+            ->with($decodedResponse)
             ->willReturn(['result']);
 
         $this->pos->cancel($order);
@@ -448,36 +409,28 @@ class GarantiPosTest extends TestCase
      */
     public function testRefundRequest(array $order, string $apiUrl): void
     {
-        $account = $this->pos->getAccount();
-        $txType = PosInterface::TX_TYPE_REFUND;
+        $account     = $this->pos->getAccount();
+        $txType      = PosInterface::TX_TYPE_REFUND;
+        $requestData = ['createRefundRequestData'];
 
         $this->requestMapperMock->expects(self::once())
             ->method('createRefundRequestData')
             ->with($account, $order)
-            ->willReturn(['createRefundRequestData']);
+            ->willReturn($requestData);
 
-        $this->serializerMock->expects(self::once())
-            ->method('encode')
-            ->with(['createRefundRequestData'], $txType)
-            ->willReturn('request-body');
-
-        $this->prepareClient(
-            $this->httpClientMock,
-            'response-body',
+        $decodedResponse = ['decodedData'];
+        $this->configureClientResponse(
+            $txType,
             $apiUrl,
-            [
-                'body'    => 'request-body',
-            ]
+            $requestData,
+            'request-body',
+            'response-body',
+            $decodedResponse,
         );
-
-        $this->serializerMock->expects(self::once())
-            ->method('decode')
-            ->with('response-body', $txType)
-            ->willReturn(['decodedResponse']);
 
         $this->responseMapperMock->expects(self::once())
             ->method('mapRefundResponse')
-            ->with(['decodedResponse'])
+            ->with($decodedResponse)
             ->willReturn(['result']);
 
         $this->pos->refund($order);
@@ -494,36 +447,28 @@ class GarantiPosTest extends TestCase
      */
     public function testOrderHistoryRequest(array $order, string $apiUrl): void
     {
-        $account = $this->pos->getAccount();
-        $txType = PosInterface::TX_TYPE_ORDER_HISTORY;
+        $account     = $this->pos->getAccount();
+        $txType      = PosInterface::TX_TYPE_ORDER_HISTORY;
+        $requestData = ['createOrderHistoryRequestData'];
 
         $this->requestMapperMock->expects(self::once())
             ->method('createOrderHistoryRequestData')
             ->with($account, $order)
-            ->willReturn(['createOrderHistoryRequestData']);
+            ->willReturn($requestData);
 
-        $this->serializerMock->expects(self::once())
-            ->method('encode')
-            ->with(['createOrderHistoryRequestData'], $txType)
-            ->willReturn('request-body');
-
-        $this->prepareClient(
-            $this->httpClientMock,
-            'response-body',
+        $decodedResponse = ['decodedData'];
+        $this->configureClientResponse(
+            $txType,
             $apiUrl,
-            [
-                'body'    => 'request-body',
-            ]
+            $requestData,
+            'request-body',
+            'response-body',
+            $decodedResponse,
         );
-
-        $this->serializerMock->expects(self::once())
-            ->method('decode')
-            ->with('response-body', $txType)
-            ->willReturn(['decodedResponse']);
 
         $this->responseMapperMock->expects(self::once())
             ->method('mapOrderHistoryResponse')
-            ->with(['decodedResponse'])
+            ->with($decodedResponse)
             ->willReturn(['result']);
 
         $this->pos->orderHistory($order);
@@ -621,7 +566,7 @@ class GarantiPosTest extends TestCase
         ];
     }
 
-    public static function historyRequestDataProvider(): array
+    public static function orderHistoryRequestDataProvider(): array
     {
         return [
             [
@@ -633,15 +578,32 @@ class GarantiPosTest extends TestCase
         ];
     }
 
-    public static function orderHistoryRequestDataProvider(): array
+    private function configureClientResponse(
+        string $txType,
+        string $apiUrl,
+        array  $requestData,
+        string $encodedRequestData,
+        string $responseContent,
+        array  $decodedResponse
+    ): void
     {
-        return [
+        $this->serializerMock->expects(self::once())
+            ->method('encode')
+            ->with($requestData, $txType)
+            ->willReturn($encodedRequestData);
+
+        $this->serializerMock->expects(self::once())
+            ->method('decode')
+            ->with($responseContent, $txType)
+            ->willReturn($decodedResponse);
+
+        $this->prepareClient(
+            $this->httpClientMock,
+            $responseContent,
+            $apiUrl,
             [
-                'order'   => [
-                    'id' => '2020110828BC',
-                ],
-                'api_url' => 'https://sanalposprovtest.garantibbva.com.tr/VPServlet',
+                'body' => $encodedRequestData,
             ],
-        ];
+        );
     }
 }

--- a/tests/Unit/Gateways/GarantiPosTest.php
+++ b/tests/Unit/Gateways/GarantiPosTest.php
@@ -215,7 +215,8 @@ class GarantiPosTest extends TestCase
                 'request-body',
                 'response-body',
                 $paymentResponse,
-                $order
+                $order,
+                PosInterface::MODEL_3D_SECURE
             );
 
             $this->responseMapperMock->expects(self::once())
@@ -301,7 +302,8 @@ class GarantiPosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -333,7 +335,8 @@ class GarantiPosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -366,7 +369,8 @@ class GarantiPosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -399,7 +403,8 @@ class GarantiPosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -432,7 +437,8 @@ class GarantiPosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -471,7 +477,8 @@ class GarantiPosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -593,7 +600,8 @@ class GarantiPosTest extends TestCase
         string $encodedRequestData,
         string $responseContent,
         array  $decodedResponse,
-        array  $order
+        array  $order,
+        string $paymentModel
     ): void
     {
         $this->serializerMock->expects(self::once())
@@ -617,12 +625,13 @@ class GarantiPosTest extends TestCase
 
         $this->eventDispatcherMock->expects(self::once())
             ->method('dispatch')
-            ->with($this->callback(function ($dispatchedEvent) use ($txType, $requestData, $order) {
+            ->with($this->callback(function ($dispatchedEvent) use ($txType, $requestData, $order, $paymentModel) {
                 return $dispatchedEvent instanceof RequestDataPreparedEvent
                     && get_class($this->pos) === $dispatchedEvent->getGatewayClass()
                     && $txType === $dispatchedEvent->getTxType()
                     && $requestData === $dispatchedEvent->getRequestData()
                     && $order === $dispatchedEvent->getOrder()
+                    && $paymentModel === $dispatchedEvent->getPaymentModel()
                     ;
             }));
     }

--- a/tests/Unit/Gateways/InterPosTest.php
+++ b/tests/Unit/Gateways/InterPosTest.php
@@ -210,6 +210,7 @@ class InterPosTest extends TestCase
                 ['request-body'],
                 'response-body',
                 $paymentResponse,
+                $order
             );
 
             $this->responseMapperMock->expects(self::once())
@@ -326,6 +327,7 @@ class InterPosTest extends TestCase
             ['request-body'],
             'response-body',
             $decodedResponse,
+            $order
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -358,6 +360,7 @@ class InterPosTest extends TestCase
             ['request-body'],
             'response-body',
             $decodedResponse,
+            $order
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -391,6 +394,7 @@ class InterPosTest extends TestCase
             ['request-body'],
             'response-body',
             $decodedResponse,
+            $order
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -423,6 +427,7 @@ class InterPosTest extends TestCase
             ['request-body'],
             'response-body',
             $decodedResponse,
+            $order
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -455,6 +460,7 @@ class InterPosTest extends TestCase
             ['request-body'],
             'response-body',
             $decodedResponse,
+            $order
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -556,7 +562,8 @@ class InterPosTest extends TestCase
         array  $requestData,
         array  $encodedRequestData,
         string $responseContent,
-        array  $decodedResponse
+        array  $decodedResponse,
+        array  $order
     ): void
     {
         $this->serializerMock->expects(self::once())
@@ -580,11 +587,12 @@ class InterPosTest extends TestCase
 
         $this->eventDispatcherMock->expects(self::once())
             ->method('dispatch')
-            ->with($this->callback(function ($dispatchedEvent) use ($txType, $requestData) {
+            ->with($this->callback(function ($dispatchedEvent) use ($txType, $requestData, $order) {
                 return $dispatchedEvent instanceof RequestDataPreparedEvent
                     && get_class($this->pos) === $dispatchedEvent->getGatewayClass()
                     && $txType === $dispatchedEvent->getTxType()
                     && $requestData === $dispatchedEvent->getRequestData()
+                    && $order === $dispatchedEvent->getOrder()
                     ;
             }));
     }

--- a/tests/Unit/Gateways/InterPosTest.php
+++ b/tests/Unit/Gateways/InterPosTest.php
@@ -10,6 +10,7 @@ use Mews\Pos\DataMapper\RequestDataMapper\RequestDataMapperInterface;
 use Mews\Pos\DataMapper\ResponseDataMapper\ResponseDataMapperInterface;
 use Mews\Pos\Entity\Account\InterPosAccount;
 use Mews\Pos\Entity\Card\CreditCardInterface;
+use Mews\Pos\Event\RequestDataPreparedEvent;
 use Mews\Pos\Exceptions\UnsupportedTransactionTypeException;
 use Mews\Pos\Factory\AccountFactory;
 use Mews\Pos\Factory\CreditCardFactory;
@@ -576,5 +577,15 @@ class InterPosTest extends TestCase
                 'form_params' => $encodedRequestData,
             ],
         );
+
+        $this->eventDispatcherMock->expects(self::once())
+            ->method('dispatch')
+            ->with($this->callback(function ($dispatchedEvent) use ($txType, $requestData) {
+                return $dispatchedEvent instanceof RequestDataPreparedEvent
+                    && get_class($this->pos) === $dispatchedEvent->getGatewayClass()
+                    && $txType === $dispatchedEvent->getTxType()
+                    && $requestData === $dispatchedEvent->getRequestData()
+                    ;
+            }));
     }
 }

--- a/tests/Unit/Gateways/InterPosTest.php
+++ b/tests/Unit/Gateways/InterPosTest.php
@@ -26,6 +26,7 @@ use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @covers \Mews\Pos\Gateways\InterPos
+ * @covers \Mews\Pos\Gateways\AbstractGateway
  */
 class InterPosTest extends TestCase
 {
@@ -200,23 +201,15 @@ class InterPosTest extends TestCase
                 ->method('create3DPaymentRequestData')
                 ->with($this->account, $order, $txType, $request->request->all())
                 ->willReturn($create3DPaymentRequestData);
-            $this->prepareClient(
-                $this->httpClientMock,
-                'response-body',
-                $this->config['gateway_endpoints']['payment_api'],
-                [
-                    'body' => 'request-body',
-                ],
-            );
 
-            $this->serializerMock->expects(self::once())
-                ->method('encode')
-                ->with($create3DPaymentRequestData, $txType)
-                ->willReturn('request-body');
-            $this->serializerMock->expects(self::once())
-                ->method('decode')
-                ->with('response-body', $txType)
-                ->willReturn($paymentResponse);
+            $this->configureClientResponse(
+                $txType,
+                $this->config['gateway_endpoints']['payment_api'],
+                $create3DPaymentRequestData,
+                ['request-body'],
+                'response-body',
+                $paymentResponse,
+            );
 
             $this->responseMapperMock->expects(self::once())
                 ->method('map3DPaymentData')
@@ -233,6 +226,8 @@ class InterPosTest extends TestCase
                 ->method('encode');
             $this->serializerMock->expects(self::never())
                 ->method('decode');
+            $this->eventDispatcherMock->expects(self::never())
+                ->method('dispatch');
         }
 
         $this->pos->make3DPayment($request, $order, $txType);
@@ -314,34 +309,27 @@ class InterPosTest extends TestCase
      */
     public function testMakeRegularPayment(array $order, string $txType, string $apiUrl): void
     {
-        $account = $this->pos->getAccount();
-        $card    = $this->card;
+        $account     = $this->pos->getAccount();
+        $card        = $this->card;
+        $requestData = ['createNonSecurePaymentRequestData'];
         $this->requestMapperMock->expects(self::once())
             ->method('createNonSecurePaymentRequestData')
             ->with($account, $order, $txType, $card)
-            ->willReturn(['createNonSecurePaymentRequestData']);
-        $this->prepareClient(
-            $this->httpClientMock,
-            'response-body',
+            ->willReturn($requestData);
+
+        $decodedResponse = ['decodedData'];
+        $this->configureClientResponse(
+            $txType,
             $apiUrl,
-            [
-                'form_params' => ['request-body'],
-            ]
+            $requestData,
+            ['request-body'],
+            'response-body',
+            $decodedResponse,
         );
-
-        $this->serializerMock->expects(self::once())
-            ->method('encode')
-            ->with(['createNonSecurePaymentRequestData'], $txType)
-            ->willReturn(['request-body']);
-
-        $this->serializerMock->expects(self::once())
-            ->method('decode')
-            ->with('response-body', $txType)
-            ->willReturn(['paymentResponse']);
 
         $this->responseMapperMock->expects(self::once())
             ->method('mapPaymentResponse')
-            ->with(['paymentResponse'], $txType, $order)
+            ->with($decodedResponse, $txType, $order)
             ->willReturn(['result']);
 
         $this->pos->makeRegularPayment($order, $card, $txType);
@@ -352,36 +340,28 @@ class InterPosTest extends TestCase
      */
     public function testMakeRegularPostAuthPayment(array $order, string $apiUrl): void
     {
-        $account = $this->pos->getAccount();
-        $txType  = PosInterface::TX_TYPE_PAY_POST_AUTH;
+        $account     = $this->pos->getAccount();
+        $txType      = PosInterface::TX_TYPE_PAY_POST_AUTH;
+        $requestData = ['createNonSecurePostAuthPaymentRequestData'];
 
         $this->requestMapperMock->expects(self::once())
             ->method('createNonSecurePostAuthPaymentRequestData')
             ->with($account, $order)
-            ->willReturn(['createNonSecurePostAuthPaymentRequestData']);
+            ->willReturn($requestData);
 
-        $this->serializerMock->expects(self::once())
-            ->method('encode')
-            ->with(['createNonSecurePostAuthPaymentRequestData'], $txType)
-            ->willReturn(['request-body']);
-
-        $this->prepareClient(
-            $this->httpClientMock,
-            'response-body',
+        $decodedResponse = ['decodedData'];
+        $this->configureClientResponse(
+            $txType,
             $apiUrl,
-            [
-                'form_params' => ['request-body'],
-            ]
+            $requestData,
+            ['request-body'],
+            'response-body',
+            $decodedResponse,
         );
-
-        $this->serializerMock->expects(self::once())
-            ->method('decode')
-            ->with('response-body', $txType)
-            ->willReturn(['paymentResponse']);
 
         $this->responseMapperMock->expects(self::once())
             ->method('mapPaymentResponse')
-            ->with(['paymentResponse'], $txType, $order)
+            ->with($decodedResponse, $txType, $order)
             ->willReturn(['result']);
 
         $this->pos->makeRegularPostPayment($order);
@@ -393,36 +373,28 @@ class InterPosTest extends TestCase
      */
     public function testStatusRequest(array $order, string $apiUrl): void
     {
-        $account = $this->pos->getAccount();
-        $txType = PosInterface::TX_TYPE_STATUS;
+        $account     = $this->pos->getAccount();
+        $txType      = PosInterface::TX_TYPE_STATUS;
+        $requestData = ['createStatusRequestData'];
 
         $this->requestMapperMock->expects(self::once())
             ->method('createStatusRequestData')
             ->with($account, $order)
-            ->willReturn(['createStatusRequestData']);
+            ->willReturn($requestData);
 
-        $this->serializerMock->expects(self::once())
-            ->method('encode')
-            ->with(['createStatusRequestData'], $txType)
-            ->willReturn(['request-body']);
-
-        $this->prepareClient(
-            $this->httpClientMock,
-            'response-body',
+        $decodedResponse = ['decodedData'];
+        $this->configureClientResponse(
+            $txType,
             $apiUrl,
-            [
-                'form_params' => ['request-body'],
-            ]
+            $requestData,
+            ['request-body'],
+            'response-body',
+            $decodedResponse,
         );
-
-        $this->serializerMock->expects(self::once())
-            ->method('decode')
-            ->with('response-body', $txType)
-            ->willReturn(['decodedResponse']);
 
         $this->responseMapperMock->expects(self::once())
             ->method('mapStatusResponse')
-            ->with(['decodedResponse'])
+            ->with($decodedResponse)
             ->willReturn(['result']);
 
         $this->pos->status($order);
@@ -433,36 +405,28 @@ class InterPosTest extends TestCase
      */
     public function testCancelRequest(array $order, string $apiUrl): void
     {
-        $account = $this->pos->getAccount();
-        $txType = PosInterface::TX_TYPE_CANCEL;
+        $account     = $this->pos->getAccount();
+        $txType      = PosInterface::TX_TYPE_CANCEL;
+        $requestData = ['createCancelRequestData'];
 
         $this->requestMapperMock->expects(self::once())
             ->method('createCancelRequestData')
             ->with($account, $order)
-            ->willReturn(['createCancelRequestData']);
+            ->willReturn($requestData);
 
-        $this->serializerMock->expects(self::once())
-            ->method('encode')
-            ->with(['createCancelRequestData'], $txType)
-            ->willReturn(['request-body']);
-
-        $this->prepareClient(
-            $this->httpClientMock,
-            'response-body',
+        $decodedResponse = ['decodedData'];
+        $this->configureClientResponse(
+            $txType,
             $apiUrl,
-            [
-                'form_params' => ['request-body'],
-            ]
+            $requestData,
+            ['request-body'],
+            'response-body',
+            $decodedResponse,
         );
-
-        $this->serializerMock->expects(self::once())
-            ->method('decode')
-            ->with('response-body', $txType)
-            ->willReturn(['decodedResponse']);
 
         $this->responseMapperMock->expects(self::once())
             ->method('mapCancelResponse')
-            ->with(['decodedResponse'])
+            ->with($decodedResponse)
             ->willReturn(['result']);
 
         $this->pos->cancel($order);
@@ -473,36 +437,28 @@ class InterPosTest extends TestCase
      */
     public function testRefundRequest(array $order, string $apiUrl): void
     {
-        $account = $this->pos->getAccount();
-        $txType = PosInterface::TX_TYPE_REFUND;
+        $account     = $this->pos->getAccount();
+        $txType      = PosInterface::TX_TYPE_REFUND;
+        $requestData = ['createRefundRequestData'];
 
         $this->requestMapperMock->expects(self::once())
             ->method('createRefundRequestData')
             ->with($account, $order)
-            ->willReturn(['createRefundRequestData']);
+            ->willReturn($requestData);
 
-        $this->serializerMock->expects(self::once())
-            ->method('encode')
-            ->with(['createRefundRequestData'], $txType)
-            ->willReturn(['request-body']);
-
-        $this->prepareClient(
-            $this->httpClientMock,
-            'response-body',
+        $decodedResponse = ['decodedData'];
+        $this->configureClientResponse(
+            $txType,
             $apiUrl,
-            [
-                'form_params' => ['request-body'],
-            ]
+            $requestData,
+            ['request-body'],
+            'response-body',
+            $decodedResponse,
         );
-
-        $this->serializerMock->expects(self::once())
-            ->method('decode')
-            ->with('response-body', $txType)
-            ->willReturn(['decodedResponse']);
 
         $this->responseMapperMock->expects(self::once())
             ->method('mapRefundResponse')
-            ->with(['decodedResponse'])
+            ->with($decodedResponse)
             ->willReturn(['result']);
 
         $this->pos->refund($order);
@@ -593,27 +549,32 @@ class InterPosTest extends TestCase
         ];
     }
 
-    public static function historyRequestDataProvider(): array
+    private function configureClientResponse(
+        string $txType,
+        string $apiUrl,
+        array  $requestData,
+        array  $encodedRequestData,
+        string $responseContent,
+        array  $decodedResponse
+    ): void
     {
-        return [
-            [
-                'order'   => [
-                    'id' => '2020110828BC',
-                ],
-                'api_url' => 'https://test.inter-vpos.com.tr/mpi/Default.aspx',
-            ],
-        ];
-    }
+        $this->serializerMock->expects(self::once())
+            ->method('encode')
+            ->with($requestData, $txType)
+            ->willReturn($encodedRequestData);
 
-    public static function orderHistoryRequestDataProvider(): array
-    {
-        return [
+        $this->serializerMock->expects(self::once())
+            ->method('decode')
+            ->with($responseContent, $txType)
+            ->willReturn($decodedResponse);
+
+        $this->prepareClient(
+            $this->httpClientMock,
+            $responseContent,
+            $apiUrl,
             [
-                'order'   => [
-                    'id' => '2020110828BC',
-                ],
-                'api_url' => 'https://test.inter-vpos.com.tr/mpi/Default.aspx',
+                'form_params' => $encodedRequestData,
             ],
-        ];
+        );
     }
 }

--- a/tests/Unit/Gateways/InterPosTest.php
+++ b/tests/Unit/Gateways/InterPosTest.php
@@ -210,7 +210,8 @@ class InterPosTest extends TestCase
                 ['request-body'],
                 'response-body',
                 $paymentResponse,
-                $order
+                $order,
+                PosInterface::MODEL_3D_SECURE
             );
 
             $this->responseMapperMock->expects(self::once())
@@ -327,7 +328,8 @@ class InterPosTest extends TestCase
             ['request-body'],
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -360,7 +362,8 @@ class InterPosTest extends TestCase
             ['request-body'],
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -394,7 +397,8 @@ class InterPosTest extends TestCase
             ['request-body'],
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -427,7 +431,8 @@ class InterPosTest extends TestCase
             ['request-body'],
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -460,7 +465,8 @@ class InterPosTest extends TestCase
             ['request-body'],
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -563,7 +569,8 @@ class InterPosTest extends TestCase
         array  $encodedRequestData,
         string $responseContent,
         array  $decodedResponse,
-        array  $order
+        array  $order,
+        string $paymentModel
     ): void
     {
         $this->serializerMock->expects(self::once())
@@ -587,12 +594,13 @@ class InterPosTest extends TestCase
 
         $this->eventDispatcherMock->expects(self::once())
             ->method('dispatch')
-            ->with($this->callback(function ($dispatchedEvent) use ($txType, $requestData, $order) {
+            ->with($this->callback(function ($dispatchedEvent) use ($txType, $requestData, $order, $paymentModel) {
                 return $dispatchedEvent instanceof RequestDataPreparedEvent
                     && get_class($this->pos) === $dispatchedEvent->getGatewayClass()
                     && $txType === $dispatchedEvent->getTxType()
                     && $requestData === $dispatchedEvent->getRequestData()
                     && $order === $dispatchedEvent->getOrder()
+                    && $paymentModel === $dispatchedEvent->getPaymentModel()
                     ;
             }));
     }

--- a/tests/Unit/Gateways/KuveytPosTest.php
+++ b/tests/Unit/Gateways/KuveytPosTest.php
@@ -204,7 +204,8 @@ class KuveytPosTest extends TestCase
             'encoded-request-data',
             $response,
             ['form_inputs' => ['form-inputs'], 'gateway' => 'form-action-url'],
-            $order
+            $order,
+            $paymentModel
         );
 
         $this->requestMapperMock->expects(self::once())
@@ -282,15 +283,16 @@ class KuveytPosTest extends TestCase
                     ],
                 ]
             );
-
+            $paymentModel = PosInterface::MODEL_3D_SECURE;
             $this->eventDispatcherMock->expects(self::once())
                 ->method('dispatch')
-                ->with($this->callback(function ($dispatchedEvent) use ($txType, $create3DPaymentRequestData, $order) {
+                ->with($this->callback(function ($dispatchedEvent) use ($txType, $create3DPaymentRequestData, $order, $paymentModel) {
                     return $dispatchedEvent instanceof RequestDataPreparedEvent
                         && get_class($this->pos) === $dispatchedEvent->getGatewayClass()
                         && $txType === $dispatchedEvent->getTxType()
                         && $create3DPaymentRequestData === $dispatchedEvent->getRequestData()
                         && $order === $dispatchedEvent->getOrder()
+                        && $paymentModel === $dispatchedEvent->getPaymentModel()
                         ;
                 }));
 
@@ -362,7 +364,8 @@ class KuveytPosTest extends TestCase
             'request-body',
             'response-body',
             $paymentResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -524,6 +527,7 @@ class KuveytPosTest extends TestCase
         string $responseContent,
         array  $decodedResponse,
         array  $order,
+        string $paymentModel,
         ?int   $statusCode = null
     ): void
     {
@@ -552,12 +556,13 @@ class KuveytPosTest extends TestCase
 
         $this->eventDispatcherMock->expects(self::once())
             ->method('dispatch')
-            ->with($this->callback(function ($dispatchedEvent) use ($txType, $requestData, $order) {
+            ->with($this->callback(function ($dispatchedEvent) use ($txType, $requestData, $order, $paymentModel) {
                 return $dispatchedEvent instanceof RequestDataPreparedEvent
                     && get_class($this->pos) === $dispatchedEvent->getGatewayClass()
                     && $txType === $dispatchedEvent->getTxType()
                     && $requestData === $dispatchedEvent->getRequestData()
                     && $order === $dispatchedEvent->getOrder()
+                    && $paymentModel === $dispatchedEvent->getPaymentModel()
                     ;
             }));
     }

--- a/tests/Unit/Gateways/PayFlexCPV4PosTest.php
+++ b/tests/Unit/Gateways/PayFlexCPV4PosTest.php
@@ -177,7 +177,8 @@ class PayFlexCPV4PosTest extends TestCase
             $requestData,
             'response-body',
             $enrollmentResponse,
-            $order
+            $order,
+            $paymentModel
         );
 
         $this->requestMapperMock->expects(self::once())
@@ -235,7 +236,8 @@ class PayFlexCPV4PosTest extends TestCase
             $requestData,
             'response-body',
             $enrollmentResponse,
-            $order
+            $order,
+            $paymentModel
         );
 
         $this->requestMapperMock->expects(self::never())
@@ -294,7 +296,8 @@ class PayFlexCPV4PosTest extends TestCase
                 $create3DPaymentStatusRequestData,
                 'response-body',
                 $paymentResponse,
-                $order
+                $order,
+                PosInterface::MODEL_3D_PAY
             );
 
             $this->responseMapperMock->expects(self::once())
@@ -344,7 +347,8 @@ class PayFlexCPV4PosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -377,7 +381,8 @@ class PayFlexCPV4PosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -416,7 +421,8 @@ class PayFlexCPV4PosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -449,7 +455,8 @@ class PayFlexCPV4PosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -571,7 +578,8 @@ class PayFlexCPV4PosTest extends TestCase
         $encodedRequestData,
         string $responseContent,
         array  $decodedResponse,
-        array  $order
+        array  $order,
+        string $paymentModel
     ): void
     {
         if ($requestData === $encodedRequestData) {
@@ -598,12 +606,13 @@ class PayFlexCPV4PosTest extends TestCase
 
         $this->eventDispatcherMock->expects(self::once())
             ->method('dispatch')
-            ->with($this->callback(function ($dispatchedEvent) use ($txType, $requestData, $order) {
+            ->with($this->callback(function ($dispatchedEvent) use ($txType, $requestData, $order, $paymentModel) {
                 return $dispatchedEvent instanceof RequestDataPreparedEvent
                     && get_class($this->pos) === $dispatchedEvent->getGatewayClass()
                     && $txType === $dispatchedEvent->getTxType()
                     && $requestData === $dispatchedEvent->getRequestData()
                     && $order === $dispatchedEvent->getOrder()
+                    && $paymentModel === $dispatchedEvent->getPaymentModel()
                     ;
             }));
     }

--- a/tests/Unit/Gateways/PayFlexCPV4PosTest.php
+++ b/tests/Unit/Gateways/PayFlexCPV4PosTest.php
@@ -177,6 +177,7 @@ class PayFlexCPV4PosTest extends TestCase
             $requestData,
             'response-body',
             $enrollmentResponse,
+            $order
         );
 
         $this->requestMapperMock->expects(self::once())
@@ -234,6 +235,7 @@ class PayFlexCPV4PosTest extends TestCase
             $requestData,
             'response-body',
             $enrollmentResponse,
+            $order
         );
 
         $this->requestMapperMock->expects(self::never())
@@ -292,6 +294,7 @@ class PayFlexCPV4PosTest extends TestCase
                 $create3DPaymentStatusRequestData,
                 'response-body',
                 $paymentResponse,
+                $order
             );
 
             $this->responseMapperMock->expects(self::once())
@@ -341,6 +344,7 @@ class PayFlexCPV4PosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
+            $order
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -373,6 +377,7 @@ class PayFlexCPV4PosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
+            $order
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -411,6 +416,7 @@ class PayFlexCPV4PosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
+            $order
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -443,6 +449,7 @@ class PayFlexCPV4PosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
+            $order
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -563,7 +570,8 @@ class PayFlexCPV4PosTest extends TestCase
         array  $requestData,
         $encodedRequestData,
         string $responseContent,
-        array  $decodedResponse
+        array  $decodedResponse,
+        array  $order
     ): void
     {
         if ($requestData === $encodedRequestData) {
@@ -590,11 +598,12 @@ class PayFlexCPV4PosTest extends TestCase
 
         $this->eventDispatcherMock->expects(self::once())
             ->method('dispatch')
-            ->with($this->callback(function ($dispatchedEvent) use ($txType, $requestData) {
+            ->with($this->callback(function ($dispatchedEvent) use ($txType, $requestData, $order) {
                 return $dispatchedEvent instanceof RequestDataPreparedEvent
                     && get_class($this->pos) === $dispatchedEvent->getGatewayClass()
                     && $txType === $dispatchedEvent->getTxType()
                     && $requestData === $dispatchedEvent->getRequestData()
+                    && $order === $dispatchedEvent->getOrder()
                     ;
             }));
     }

--- a/tests/Unit/Gateways/PayFlexV4PosTest.php
+++ b/tests/Unit/Gateways/PayFlexV4PosTest.php
@@ -154,9 +154,10 @@ class PayFlexV4PosTest extends TestCase
         $this->expectException(Exception::class);
         $txType      = PosInterface::TX_TYPE_PAY_AUTH;
         $requestData = ['request-data'];
+        $order       = $this->order;
         $this->requestMapperMock->expects(self::once())
             ->method('create3DEnrollmentCheckRequestData')
-            ->with($this->pos->getAccount(), $this->order, $this->card)
+            ->with($this->pos->getAccount(), $order, $this->card)
             ->willReturn($requestData);
 
         $this->configureClientResponse(
@@ -166,12 +167,13 @@ class PayFlexV4PosTest extends TestCase
             $requestData,
             'response-body',
             self::getSampleEnrollmentFailResponseDataProvider(),
+            $order
         );
 
         $this->requestMapperMock->expects(self::never())
             ->method('create3DFormData');
 
-        $this->pos->get3DFormData($this->order, PosInterface::MODEL_3D_SECURE, $txType, $this->card);
+        $this->pos->get3DFormData($order, PosInterface::MODEL_3D_SECURE, $txType, $this->card);
     }
 
     /**
@@ -200,6 +202,7 @@ class PayFlexV4PosTest extends TestCase
             $requestData,
             'response-body',
             $enrollmentResponse,
+            $order
         );
 
         $this->requestMapperMock->expects(self::once())
@@ -264,6 +267,7 @@ class PayFlexV4PosTest extends TestCase
                 'request-body',
                 'response-body',
                 $paymentResponse,
+                $order
             );
 
             $this->responseMapperMock->expects(self::once())
@@ -329,6 +333,7 @@ class PayFlexV4PosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
+            $order
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -360,6 +365,7 @@ class PayFlexV4PosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
+            $order
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -393,6 +399,7 @@ class PayFlexV4PosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
+            $order
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -425,6 +432,7 @@ class PayFlexV4PosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
+            $order
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -457,6 +465,7 @@ class PayFlexV4PosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
+            $order
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -610,7 +619,8 @@ class PayFlexV4PosTest extends TestCase
         array  $requestData,
         $encodedRequestData,
         string $responseContent,
-        array  $decodedResponse
+        array  $decodedResponse,
+        array  $order
     ): void
     {
         if ($requestData === $encodedRequestData) {
@@ -639,11 +649,12 @@ class PayFlexV4PosTest extends TestCase
 
         $this->eventDispatcherMock->expects(self::once())
             ->method('dispatch')
-            ->with($this->callback(function ($dispatchedEvent) use ($txType, $requestData) {
+            ->with($this->callback(function ($dispatchedEvent) use ($txType, $requestData, $order) {
                 return $dispatchedEvent instanceof RequestDataPreparedEvent
                     && get_class($this->pos) === $dispatchedEvent->getGatewayClass()
                     && $txType === $dispatchedEvent->getTxType()
                     && $requestData === $dispatchedEvent->getRequestData()
+                    && $order === $dispatchedEvent->getOrder()
                     ;
             }));
     }

--- a/tests/Unit/Gateways/PayFlexV4PosTest.php
+++ b/tests/Unit/Gateways/PayFlexV4PosTest.php
@@ -31,6 +31,7 @@ use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @covers \Mews\Pos\Gateways\PayFlexV4Pos
+ * @covers \Mews\Pos\Gateways\AbstractGateway
  */
 class PayFlexV4PosTest extends TestCase
 {
@@ -150,30 +151,26 @@ class PayFlexV4PosTest extends TestCase
     public function testGet3DFormDataEnrollmentFail(): void
     {
         $this->expectException(Exception::class);
+        $txType      = PosInterface::TX_TYPE_PAY_AUTH;
+        $requestData = ['request-data'];
         $this->requestMapperMock->expects(self::once())
             ->method('create3DEnrollmentCheckRequestData')
             ->with($this->pos->getAccount(), $this->order, $this->card)
-            ->willReturn(['request-data']);
+            ->willReturn($requestData);
 
-        $this->serializerMock->expects(self::never())
-            ->method('encode');
-
-        $this->prepareClient(
-            $this->httpClientMock,
-            'response-content',
+        $this->configureClientResponse(
+            $txType,
             $this->config['gateway_endpoints']['gateway_3d'],
-            ['form_params' => ['request-data']],
+            $requestData,
+            $requestData,
+            'response-body',
+            self::getSampleEnrollmentFailResponseDataProvider(),
         );
-
-        $this->serializerMock->expects(self::once())
-            ->method('decode')
-            ->with('response-content', PosInterface::TX_TYPE_PAY_AUTH)
-            ->willReturn(self::getSampleEnrollmentFailResponseDataProvider());
 
         $this->requestMapperMock->expects(self::never())
             ->method('create3DFormData');
 
-        $this->pos->get3DFormData($this->order, PosInterface::MODEL_3D_SECURE, PosInterface::TX_TYPE_PAY_AUTH, $this->card);
+        $this->pos->get3DFormData($this->order, PosInterface::MODEL_3D_SECURE, $txType, $this->card);
     }
 
     /**
@@ -184,30 +181,25 @@ class PayFlexV4PosTest extends TestCase
     public function testGet3DFormDataSuccess(): void
     {
         $enrollmentResponse = PayFlexV4PosRequestDataMapperTest::getSampleEnrollmentSuccessResponseDataProvider();
-        $txType = PosInterface::TX_TYPE_PAY_AUTH;
-        $paymentModel = PosInterface::MODEL_3D_SECURE;
-        $card = $this->card;
-        $order = $this->order;
+        $txType             = PosInterface::TX_TYPE_PAY_AUTH;
+        $paymentModel       = PosInterface::MODEL_3D_SECURE;
+        $card               = $this->card;
+        $order              = $this->order;
+        $requestData        = ['request-data'];
 
         $this->requestMapperMock->expects(self::once())
             ->method('create3DEnrollmentCheckRequestData')
             ->with($this->pos->getAccount(), $order, $card)
-            ->willReturn(['request-data']);
+            ->willReturn($requestData);
 
-        $this->serializerMock->expects(self::never())
-            ->method('encode');
-
-        $this->prepareClient(
-            $this->httpClientMock,
-            'response-content',
+        $this->configureClientResponse(
+            $txType,
             $this->config['gateway_endpoints']['gateway_3d'],
-            ['form_params' => ['request-data']],
+            $requestData,
+            $requestData,
+            'response-body',
+            $enrollmentResponse,
         );
-
-        $this->serializerMock->expects(self::once())
-            ->method('decode')
-            ->with('response-content', $txType)
-            ->willReturn($enrollmentResponse);
 
         $this->requestMapperMock->expects(self::once())
             ->method('create3DFormData')
@@ -263,23 +255,15 @@ class PayFlexV4PosTest extends TestCase
                 ->method('create3DPaymentRequestData')
                 ->with($this->account, $order, $txType, $request->request->all())
                 ->willReturn($create3DPaymentRequestData);
-            $this->prepareClient(
-                $this->httpClientMock,
-                'response-body',
-                $this->config['gateway_endpoints']['payment_api'],
-                [
-                    'form_params' => ['prmstr' => 'request-body'],
-                ],
-            );
 
-            $this->serializerMock->expects(self::once())
-                ->method('encode')
-                ->with($create3DPaymentRequestData, $txType)
-                ->willReturn('request-body');
-            $this->serializerMock->expects(self::once())
-                ->method('decode')
-                ->with('response-body', $txType)
-                ->willReturn($paymentResponse);
+            $this->configureClientResponse(
+                $txType,
+                $this->config['gateway_endpoints']['payment_api'],
+                $create3DPaymentRequestData,
+                'request-body',
+                'response-body',
+                $paymentResponse,
+            );
 
             $this->responseMapperMock->expects(self::once())
                 ->method('map3DPaymentData')
@@ -296,6 +280,8 @@ class PayFlexV4PosTest extends TestCase
                 ->method('encode');
             $this->serializerMock->expects(self::never())
                 ->method('decode');
+            $this->eventDispatcherMock->expects(self::never())
+                ->method('dispatch');
         }
 
         $this->pos->make3DPayment($request, $order, $txType);
@@ -326,34 +312,27 @@ class PayFlexV4PosTest extends TestCase
      */
     public function testMakeRegularPayment(array $order, string $txType, string $apiUrl): void
     {
-        $account = $this->pos->getAccount();
-        $card    = $this->card;
+        $account     = $this->pos->getAccount();
+        $card        = $this->card;
+        $requestData = ['createNonSecurePaymentRequestData'];
         $this->requestMapperMock->expects(self::once())
             ->method('createNonSecurePaymentRequestData')
             ->with($account, $order, $txType, $card)
-            ->willReturn(['createNonSecurePaymentRequestData']);
-        $this->prepareClient(
-            $this->httpClientMock,
-            'response-body',
+            ->willReturn($requestData);
+
+        $decodedResponse = ['decodedData'];
+        $this->configureClientResponse(
+            $txType,
             $apiUrl,
-            [
-                'form_params' => ['prmstr' => 'request-body'],
-            ]
+            $requestData,
+            'request-body',
+            'response-body',
+            $decodedResponse,
         );
-
-        $this->serializerMock->expects(self::once())
-            ->method('encode')
-            ->with(['createNonSecurePaymentRequestData'], $txType)
-            ->willReturn('request-body');
-
-        $this->serializerMock->expects(self::once())
-            ->method('decode')
-            ->with('response-body', $txType)
-            ->willReturn(['paymentResponse']);
 
         $this->responseMapperMock->expects(self::once())
             ->method('mapPaymentResponse')
-            ->with(['paymentResponse'], $txType, $order)
+            ->with($decodedResponse, $txType, $order)
             ->willReturn(['result']);
 
         $this->pos->makeRegularPayment($order, $card, $txType);
@@ -364,36 +343,27 @@ class PayFlexV4PosTest extends TestCase
      */
     public function testMakeRegularPostAuthPayment(array $order, string $apiUrl): void
     {
-        $account = $this->pos->getAccount();
-        $txType  = PosInterface::TX_TYPE_PAY_POST_AUTH;
-
+        $account     = $this->pos->getAccount();
+        $txType      = PosInterface::TX_TYPE_PAY_POST_AUTH;
+        $requestData = ['createNonSecurePostAuthPaymentRequestData'];
         $this->requestMapperMock->expects(self::once())
             ->method('createNonSecurePostAuthPaymentRequestData')
             ->with($account, $order)
-            ->willReturn(['createNonSecurePostAuthPaymentRequestData']);
+            ->willReturn($requestData);
 
-        $this->serializerMock->expects(self::once())
-            ->method('encode')
-            ->with(['createNonSecurePostAuthPaymentRequestData'], $txType)
-            ->willReturn('request-body');
-
-        $this->prepareClient(
-            $this->httpClientMock,
-            'response-body',
+        $decodedResponse = ['decodedData'];
+        $this->configureClientResponse(
+            $txType,
             $apiUrl,
-            [
-                'form_params' => ['prmstr' => 'request-body'],
-            ]
+            $requestData,
+            'request-body',
+            'response-body',
+            $decodedResponse,
         );
-
-        $this->serializerMock->expects(self::once())
-            ->method('decode')
-            ->with('response-body', $txType)
-            ->willReturn(['paymentResponse']);
 
         $this->responseMapperMock->expects(self::once())
             ->method('mapPaymentResponse')
-            ->with(['paymentResponse'], $txType, $order)
+            ->with($decodedResponse, $txType, $order)
             ->willReturn(['result']);
 
         $this->pos->makeRegularPostPayment($order);
@@ -405,36 +375,28 @@ class PayFlexV4PosTest extends TestCase
      */
     public function testStatusRequest(array $order, string $apiUrl): void
     {
-        $account = $this->pos->getAccount();
-        $txType = PosInterface::TX_TYPE_STATUS;
+        $account     = $this->pos->getAccount();
+        $txType      = PosInterface::TX_TYPE_STATUS;
+        $requestData = ['createStatusRequestData'];
 
         $this->requestMapperMock->expects(self::once())
             ->method('createStatusRequestData')
             ->with($account, $order)
-            ->willReturn(['createStatusRequestData']);
+            ->willReturn($requestData);
 
-        $this->serializerMock->expects(self::once())
-            ->method('encode')
-            ->with(['createStatusRequestData'], $txType)
-            ->willReturn('request-body');
-
-        $this->prepareClient(
-            $this->httpClientMock,
-            'response-body',
+        $decodedResponse = ['decodedData'];
+        $this->configureClientResponse(
+            $txType,
             $apiUrl,
-            [
-                'form_params' => ['prmstr' => 'request-body'],
-            ]
+            $requestData,
+            'request-body',
+            'response-body',
+            $decodedResponse,
         );
-
-        $this->serializerMock->expects(self::once())
-            ->method('decode')
-            ->with('response-body', $txType)
-            ->willReturn(['decodedResponse']);
 
         $this->responseMapperMock->expects(self::once())
             ->method('mapStatusResponse')
-            ->with(['decodedResponse'])
+            ->with($decodedResponse)
             ->willReturn(['result']);
 
         $this->pos->status($order);
@@ -445,36 +407,28 @@ class PayFlexV4PosTest extends TestCase
      */
     public function testCancelRequest(array $order, string $apiUrl): void
     {
-        $account = $this->pos->getAccount();
-        $txType = PosInterface::TX_TYPE_CANCEL;
+        $account     = $this->pos->getAccount();
+        $txType      = PosInterface::TX_TYPE_CANCEL;
+        $requestData = ['createCancelRequestData'];
 
         $this->requestMapperMock->expects(self::once())
             ->method('createCancelRequestData')
             ->with($account, $order)
-            ->willReturn(['createCancelRequestData']);
+            ->willReturn($requestData);
 
-        $this->serializerMock->expects(self::once())
-            ->method('encode')
-            ->with(['createCancelRequestData'], $txType)
-            ->willReturn('request-body');
-
-        $this->prepareClient(
-            $this->httpClientMock,
-            'response-body',
+        $decodedResponse = ['decodedData'];
+        $this->configureClientResponse(
+            $txType,
             $apiUrl,
-            [
-                'form_params' => ['prmstr' => 'request-body'],
-            ]
+            $requestData,
+            'request-body',
+            'response-body',
+            $decodedResponse,
         );
-
-        $this->serializerMock->expects(self::once())
-            ->method('decode')
-            ->with('response-body', $txType)
-            ->willReturn(['decodedResponse']);
 
         $this->responseMapperMock->expects(self::once())
             ->method('mapCancelResponse')
-            ->with(['decodedResponse'])
+            ->with($decodedResponse)
             ->willReturn(['result']);
 
         $this->pos->cancel($order);
@@ -485,36 +439,28 @@ class PayFlexV4PosTest extends TestCase
      */
     public function testRefundRequest(array $order, string $apiUrl): void
     {
-        $account = $this->pos->getAccount();
-        $txType = PosInterface::TX_TYPE_REFUND;
+        $account     = $this->pos->getAccount();
+        $txType      = PosInterface::TX_TYPE_REFUND;
+        $requestData = ['createRefundRequestData'];
 
         $this->requestMapperMock->expects(self::once())
             ->method('createRefundRequestData')
             ->with($account, $order)
-            ->willReturn(['createRefundRequestData']);
+            ->willReturn($requestData);
 
-        $this->serializerMock->expects(self::once())
-            ->method('encode')
-            ->with(['createRefundRequestData'], $txType)
-            ->willReturn('request-body');
-
-        $this->prepareClient(
-            $this->httpClientMock,
-            'response-body',
+        $decodedResponse = ['decodedData'];
+        $this->configureClientResponse(
+            $txType,
             $apiUrl,
-            [
-                'form_params' => ['prmstr' => 'request-body'],
-            ]
+            $requestData,
+            'request-body',
+            'response-body',
+            $decodedResponse,
         );
-
-        $this->serializerMock->expects(self::once())
-            ->method('decode')
-            ->with('response-body', $txType)
-            ->willReturn(['decodedResponse']);
 
         $this->responseMapperMock->expects(self::once())
             ->method('mapRefundResponse')
-            ->with(['decodedResponse'])
+            ->with($decodedResponse)
             ->willReturn(['result']);
 
         $this->pos->refund($order);
@@ -658,5 +604,39 @@ class PayFlexV4PosTest extends TestCase
                 'isSuccess'       => true,
             ],
         ];
+    }
+
+    private function configureClientResponse(
+        string $txType,
+        string $apiUrl,
+        array  $requestData,
+        $encodedRequestData,
+        string $responseContent,
+        array  $decodedResponse
+    ): void
+    {
+        if ($requestData === $encodedRequestData) {
+            $this->serializerMock->expects(self::never())
+                ->method('encode');
+        } else {
+            $this->serializerMock->expects(self::once())
+                ->method('encode')
+                ->with($requestData, $txType)
+                ->willReturn($encodedRequestData);
+        }
+
+        $this->serializerMock->expects(self::once())
+            ->method('decode')
+            ->with($responseContent, $txType)
+            ->willReturn($decodedResponse);
+
+        $this->prepareClient(
+            $this->httpClientMock,
+            $responseContent,
+            $apiUrl,
+            [
+                'form_params' => is_string($encodedRequestData) ? ['prmstr' => $encodedRequestData] : $encodedRequestData
+            ]
+        );
     }
 }

--- a/tests/Unit/Gateways/PayFlexV4PosTest.php
+++ b/tests/Unit/Gateways/PayFlexV4PosTest.php
@@ -167,7 +167,8 @@ class PayFlexV4PosTest extends TestCase
             $requestData,
             'response-body',
             self::getSampleEnrollmentFailResponseDataProvider(),
-            $order
+            $order,
+            PosInterface::MODEL_3D_SECURE
         );
 
         $this->requestMapperMock->expects(self::never())
@@ -202,7 +203,8 @@ class PayFlexV4PosTest extends TestCase
             $requestData,
             'response-body',
             $enrollmentResponse,
-            $order
+            $order,
+            $paymentModel
         );
 
         $this->requestMapperMock->expects(self::once())
@@ -267,7 +269,8 @@ class PayFlexV4PosTest extends TestCase
                 'request-body',
                 'response-body',
                 $paymentResponse,
-                $order
+                $order,
+                PosInterface::MODEL_3D_SECURE
             );
 
             $this->responseMapperMock->expects(self::once())
@@ -333,7 +336,8 @@ class PayFlexV4PosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -365,7 +369,8 @@ class PayFlexV4PosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -399,7 +404,8 @@ class PayFlexV4PosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -432,7 +438,8 @@ class PayFlexV4PosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -465,7 +472,8 @@ class PayFlexV4PosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -620,7 +628,8 @@ class PayFlexV4PosTest extends TestCase
         $encodedRequestData,
         string $responseContent,
         array  $decodedResponse,
-        array  $order
+        array  $order,
+        string $paymentModel
     ): void
     {
         if ($requestData === $encodedRequestData) {
@@ -649,12 +658,13 @@ class PayFlexV4PosTest extends TestCase
 
         $this->eventDispatcherMock->expects(self::once())
             ->method('dispatch')
-            ->with($this->callback(function ($dispatchedEvent) use ($txType, $requestData, $order) {
+            ->with($this->callback(function ($dispatchedEvent) use ($txType, $requestData, $order, $paymentModel) {
                 return $dispatchedEvent instanceof RequestDataPreparedEvent
                     && get_class($this->pos) === $dispatchedEvent->getGatewayClass()
                     && $txType === $dispatchedEvent->getTxType()
                     && $requestData === $dispatchedEvent->getRequestData()
                     && $order === $dispatchedEvent->getOrder()
+                    && $paymentModel === $dispatchedEvent->getPaymentModel()
                     ;
             }));
     }

--- a/tests/Unit/Gateways/PayForTest.php
+++ b/tests/Unit/Gateways/PayForTest.php
@@ -11,6 +11,7 @@ use Mews\Pos\DataMapper\RequestDataMapper\RequestDataMapperInterface;
 use Mews\Pos\DataMapper\ResponseDataMapper\ResponseDataMapperInterface;
 use Mews\Pos\Entity\Account\PayForAccount;
 use Mews\Pos\Entity\Card\CreditCardInterface;
+use Mews\Pos\Event\RequestDataPreparedEvent;
 use Mews\Pos\Factory\AccountFactory;
 use Mews\Pos\Factory\CreditCardFactory;
 use Mews\Pos\Gateways\PayForPos;
@@ -688,5 +689,15 @@ class PayForTest extends TestCase
                 'body'    => $encodedRequestData,
             ],
         );
+
+        $this->eventDispatcherMock->expects(self::once())
+            ->method('dispatch')
+            ->with($this->callback(function ($dispatchedEvent) use ($txType, $requestData) {
+                return $dispatchedEvent instanceof RequestDataPreparedEvent
+                    && get_class($this->pos) === $dispatchedEvent->getGatewayClass()
+                    && $txType === $dispatchedEvent->getTxType()
+                    && $requestData === $dispatchedEvent->getRequestData()
+                    ;
+            }));
     }
 }

--- a/tests/Unit/Gateways/PayForTest.php
+++ b/tests/Unit/Gateways/PayForTest.php
@@ -26,6 +26,7 @@ use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @covers \Mews\Pos\Gateways\PayForPos
+ * @covers \Mews\Pos\Gateways\AbstractGateway
  */
 class PayForTest extends TestCase
 {
@@ -218,26 +219,15 @@ class PayForTest extends TestCase
                 ->method('create3DPaymentRequestData')
                 ->with($this->account, $order, $txType, $request->request->all())
                 ->willReturn($create3DPaymentRequestData);
-            $this->prepareClient(
-                $this->httpClientMock,
-                'response-body',
-                $this->config['gateway_endpoints']['payment_api'],
-                [
-                    'headers' => [
-                        'Content-Type' => 'text/xml; charset=UTF-8',
-                    ],
-                    'body'    => 'request-body',
-                ],
-            );
 
-            $this->serializerMock->expects(self::once())
-                ->method('encode')
-                ->with($create3DPaymentRequestData, $txType)
-                ->willReturn('request-body');
-            $this->serializerMock->expects(self::once())
-                ->method('decode')
-                ->with('response-body', $txType)
-                ->willReturn($paymentResponse);
+            $this->configureClientResponse(
+                $txType,
+                $this->config['gateway_endpoints']['payment_api'],
+                $create3DPaymentRequestData,
+                'request-body',
+                'response-body',
+                $paymentResponse,
+            );
 
             $this->responseMapperMock->expects(self::once())
                 ->method('map3DPaymentData')
@@ -254,6 +244,8 @@ class PayForTest extends TestCase
                 ->method('encode');
             $this->serializerMock->expects(self::never())
                 ->method('decode');
+            $this->eventDispatcherMock->expects(self::never())
+                ->method('dispatch');
         }
 
         $this->pos->make3DPayment($request, $order, $txType);
@@ -322,37 +314,27 @@ class PayForTest extends TestCase
      */
     public function testMakeRegularPayment(array $order, string $txType, string $apiUrl): void
     {
-        $account = $this->pos->getAccount();
-        $card    = $this->card;
+        $account     = $this->pos->getAccount();
+        $card        = $this->card;
+        $requestData = ['createNonSecurePaymentRequestData'];
         $this->requestMapperMock->expects(self::once())
             ->method('createNonSecurePaymentRequestData')
             ->with($account, $order, $txType, $card)
-            ->willReturn(['createNonSecurePaymentRequestData']);
-        $this->prepareClient(
-            $this->httpClientMock,
-            'response-body',
+            ->willReturn($requestData);
+
+        $decodedResponse = ['decodedData'];
+        $this->configureClientResponse(
+            $txType,
             $apiUrl,
-            [
-                'body'    => 'request-body',
-                'headers' => [
-                    'Content-Type' => 'text/xml; charset=UTF-8',
-                ],
-            ]
+            $requestData,
+            'request-body',
+            'response-body',
+            $decodedResponse,
         );
-
-        $this->serializerMock->expects(self::once())
-            ->method('encode')
-            ->with(['createNonSecurePaymentRequestData'], $txType)
-            ->willReturn('request-body');
-
-        $this->serializerMock->expects(self::once())
-            ->method('decode')
-            ->with('response-body', $txType)
-            ->willReturn(['paymentResponse']);
 
         $this->responseMapperMock->expects(self::once())
             ->method('mapPaymentResponse')
-            ->with(['paymentResponse'], $txType, $order)
+            ->with($decodedResponse, $txType, $order)
             ->willReturn(['result']);
 
         $this->pos->makeRegularPayment($order, $card, $txType);
@@ -363,39 +345,28 @@ class PayForTest extends TestCase
      */
     public function testMakeRegularPostAuthPayment(array $order, string $apiUrl): void
     {
-        $account = $this->pos->getAccount();
-        $txType  = PosInterface::TX_TYPE_PAY_POST_AUTH;
+        $account     = $this->pos->getAccount();
+        $txType      = PosInterface::TX_TYPE_PAY_POST_AUTH;
+        $requestData = ['createNonSecurePostAuthPaymentRequestData'];
 
         $this->requestMapperMock->expects(self::once())
             ->method('createNonSecurePostAuthPaymentRequestData')
             ->with($account, $order)
-            ->willReturn(['createNonSecurePostAuthPaymentRequestData']);
+            ->willReturn($requestData);
 
-        $this->serializerMock->expects(self::once())
-            ->method('encode')
-            ->with(['createNonSecurePostAuthPaymentRequestData'], $txType)
-            ->willReturn('request-body');
-
-        $this->prepareClient(
-            $this->httpClientMock,
-            'response-body',
+        $decodedResponse = ['decodedData'];
+        $this->configureClientResponse(
+            $txType,
             $apiUrl,
-            [
-                'body'    => 'request-body',
-                'headers' => [
-                    'Content-Type' => 'text/xml; charset=UTF-8',
-                ],
-            ]
+            $requestData,
+            'request-body',
+            'response-body',
+            $decodedResponse,
         );
-
-        $this->serializerMock->expects(self::once())
-            ->method('decode')
-            ->with('response-body', $txType)
-            ->willReturn(['paymentResponse']);
 
         $this->responseMapperMock->expects(self::once())
             ->method('mapPaymentResponse')
-            ->with(['paymentResponse'], $txType, $order)
+            ->with($decodedResponse, $txType, $order)
             ->willReturn(['result']);
 
         $this->pos->makeRegularPostPayment($order);
@@ -407,40 +378,28 @@ class PayForTest extends TestCase
      */
     public function testStatusRequest(array $order, string $apiUrl): void
     {
-        $account = $this->pos->getAccount();
-        $txType = PosInterface::TX_TYPE_STATUS;
+        $account     = $this->pos->getAccount();
+        $txType      = PosInterface::TX_TYPE_STATUS;
+        $requestData = ['createStatusRequestData'];
 
         $this->requestMapperMock->expects(self::once())
             ->method('createStatusRequestData')
             ->with($account, $order)
-            ->willReturn(['createStatusRequestData']);
+            ->willReturn($requestData);
 
-        $this->serializerMock->expects(self::once())
-            ->method('encode')
-            ->with(['createStatusRequestData'], $txType)
-            ->willReturn('request-body');
-
-        $this->prepareClient(
-            $this->httpClientMock,
-            'response-body',
+        $decodedResponse = ['decodedData'];
+        $this->configureClientResponse(
+            $txType,
             $apiUrl,
-            [
-                'body'    => 'request-body',
-                'headers' => [
-                    'Content-Type' => 'text/xml; charset=UTF-8',
-                ],
-            ]
+            $requestData,
+            'request-body',
+            'response-body',
+            $decodedResponse,
         );
-
-
-        $this->serializerMock->expects(self::once())
-            ->method('decode')
-            ->with('response-body', $txType)
-            ->willReturn(['decodedResponse']);
 
         $this->responseMapperMock->expects(self::once())
             ->method('mapStatusResponse')
-            ->with(['decodedResponse'])
+            ->with($decodedResponse)
             ->willReturn(['result']);
 
         $this->pos->status($order);
@@ -451,39 +410,28 @@ class PayForTest extends TestCase
      */
     public function testCancelRequest(array $order, string $apiUrl): void
     {
-        $account = $this->pos->getAccount();
-        $txType = PosInterface::TX_TYPE_CANCEL;
+        $account     = $this->pos->getAccount();
+        $txType      = PosInterface::TX_TYPE_CANCEL;
+        $requestData = ['createCancelRequestData'];
 
         $this->requestMapperMock->expects(self::once())
             ->method('createCancelRequestData')
             ->with($account, $order)
-            ->willReturn(['createCancelRequestData']);
+            ->willReturn($requestData);
 
-        $this->serializerMock->expects(self::once())
-            ->method('encode')
-            ->with(['createCancelRequestData'], $txType)
-            ->willReturn('request-body');
-
-        $this->prepareClient(
-            $this->httpClientMock,
-            'response-body',
+        $decodedResponse = ['decodedData'];
+        $this->configureClientResponse(
+            $txType,
             $apiUrl,
-            [
-                'body'    => 'request-body',
-                'headers' => [
-                    'Content-Type' => 'text/xml; charset=UTF-8',
-                ],
-            ]
+            $requestData,
+            'request-body',
+            'response-body',
+            $decodedResponse,
         );
-
-        $this->serializerMock->expects(self::once())
-            ->method('decode')
-            ->with('response-body', $txType)
-            ->willReturn(['decodedResponse']);
 
         $this->responseMapperMock->expects(self::once())
             ->method('mapCancelResponse')
-            ->with(['decodedResponse'])
+            ->with($decodedResponse)
             ->willReturn(['result']);
 
         $this->pos->cancel($order);
@@ -494,39 +442,28 @@ class PayForTest extends TestCase
      */
     public function testRefundRequest(array $order, string $apiUrl): void
     {
-        $account = $this->pos->getAccount();
-        $txType = PosInterface::TX_TYPE_REFUND;
+        $account     = $this->pos->getAccount();
+        $txType      = PosInterface::TX_TYPE_REFUND;
+        $requestData = ['createRefundRequestData'];
 
         $this->requestMapperMock->expects(self::once())
             ->method('createRefundRequestData')
             ->with($account, $order)
-            ->willReturn(['createRefundRequestData']);
+            ->willReturn($requestData);
 
-        $this->serializerMock->expects(self::once())
-            ->method('encode')
-            ->with(['createRefundRequestData'], $txType)
-            ->willReturn('request-body');
-
-        $this->prepareClient(
-            $this->httpClientMock,
-            'response-body',
+        $decodedResponse = ['decodedData'];
+        $this->configureClientResponse(
+            $txType,
             $apiUrl,
-            [
-                'body'    => 'request-body',
-                'headers' => [
-                    'Content-Type' => 'text/xml; charset=UTF-8',
-                ],
-            ]
+            $requestData,
+            'request-body',
+            'response-body',
+            $decodedResponse,
         );
-
-        $this->serializerMock->expects(self::once())
-            ->method('decode')
-            ->with('response-body', $txType)
-            ->willReturn(['decodedResponse']);
 
         $this->responseMapperMock->expects(self::once())
             ->method('mapRefundResponse')
-            ->with(['decodedResponse'])
+            ->with($decodedResponse)
             ->willReturn(['result']);
 
         $this->pos->refund($order);
@@ -537,39 +474,28 @@ class PayForTest extends TestCase
      */
     public function testHistoryRequest(array $order, string $apiUrl): void
     {
-        $account = $this->pos->getAccount();
-        $txType = PosInterface::TX_TYPE_HISTORY;
+        $account     = $this->pos->getAccount();
+        $txType      = PosInterface::TX_TYPE_HISTORY;
+        $requestData = ['createHistoryRequestData'];
 
         $this->requestMapperMock->expects(self::once())
             ->method('createHistoryRequestData')
             ->with($account, $order)
-            ->willReturn(['createHistoryRequestData']);
+            ->willReturn($requestData);
 
-        $this->serializerMock->expects(self::once())
-            ->method('encode')
-            ->with(['createHistoryRequestData'], $txType)
-            ->willReturn('request-body');
-
-        $this->prepareClient(
-            $this->httpClientMock,
-            'response-body',
+        $decodedResponse = ['decodedData'];
+        $this->configureClientResponse(
+            $txType,
             $apiUrl,
-            [
-                'body'    => 'request-body',
-                'headers' => [
-                    'Content-Type' => 'text/xml; charset=UTF-8',
-                ],
-            ]
+            $requestData,
+            'request-body',
+            'response-body',
+            $decodedResponse,
         );
-
-        $this->serializerMock->expects(self::once())
-            ->method('decode')
-            ->with('response-body', $txType)
-            ->willReturn(['decodedResponse']);
 
         $this->responseMapperMock->expects(self::once())
             ->method('mapHistoryResponse')
-            ->with(['decodedResponse'])
+            ->with($decodedResponse)
             ->willReturn(['result']);
 
         $this->pos->history($order);
@@ -580,39 +506,28 @@ class PayForTest extends TestCase
      */
     public function testOrderHistoryRequest(array $order, string $apiUrl): void
     {
-        $account = $this->pos->getAccount();
-        $txType = PosInterface::TX_TYPE_ORDER_HISTORY;
+        $account     = $this->pos->getAccount();
+        $txType      = PosInterface::TX_TYPE_ORDER_HISTORY;
+        $requestData = ['createOrderHistoryRequestData'];
 
         $this->requestMapperMock->expects(self::once())
             ->method('createOrderHistoryRequestData')
             ->with($account, $order)
-            ->willReturn(['createOrderHistoryRequestData']);
+            ->willReturn($requestData);
 
-        $this->serializerMock->expects(self::once())
-            ->method('encode')
-            ->with(['createOrderHistoryRequestData'], $txType)
-            ->willReturn('request-body');
-
-        $this->prepareClient(
-            $this->httpClientMock,
-            'response-body',
+        $decodedResponse = ['decodedData'];
+        $this->configureClientResponse(
+            $txType,
             $apiUrl,
-            [
-                'body'    => 'request-body',
-                'headers' => [
-                    'Content-Type' => 'text/xml; charset=UTF-8',
-                ],
-            ]
+            $requestData,
+            'request-body',
+            'response-body',
+            $decodedResponse,
         );
-
-        $this->serializerMock->expects(self::once())
-            ->method('decode')
-            ->with('response-body', $txType)
-            ->willReturn(['decodedResponse']);
 
         $this->responseMapperMock->expects(self::once())
             ->method('mapOrderHistoryResponse')
-            ->with(['decodedResponse'])
+            ->with($decodedResponse)
             ->willReturn(['result']);
 
         $this->pos->orderHistory($order);
@@ -741,5 +656,37 @@ class PayForTest extends TestCase
                 'api_url' => 'https://vpostest.qnbfinansbank.com/Gateway/XMLGate.aspx',
             ],
         ];
+    }
+
+    private function configureClientResponse(
+        string $txType,
+        string $apiUrl,
+        array  $requestData,
+        string $encodedRequestData,
+        string $responseContent,
+        array  $decodedResponse
+    ): void
+    {
+        $this->serializerMock->expects(self::once())
+            ->method('encode')
+            ->with($requestData, $txType)
+            ->willReturn($encodedRequestData);
+
+        $this->serializerMock->expects(self::once())
+            ->method('decode')
+            ->with($responseContent, $txType)
+            ->willReturn($decodedResponse);
+
+        $this->prepareClient(
+            $this->httpClientMock,
+            $responseContent,
+            $apiUrl,
+            [
+                'headers' => [
+                    'Content-Type' => 'text/xml; charset=UTF-8',
+                ],
+                'body'    => $encodedRequestData,
+            ],
+        );
     }
 }

--- a/tests/Unit/Gateways/PayForTest.php
+++ b/tests/Unit/Gateways/PayForTest.php
@@ -228,7 +228,8 @@ class PayForTest extends TestCase
                 'request-body',
                 'response-body',
                 $paymentResponse,
-                $order
+                $order,
+                PosInterface::MODEL_3D_SECURE
             );
 
             $this->responseMapperMock->expects(self::once())
@@ -332,7 +333,8 @@ class PayForTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -365,7 +367,8 @@ class PayForTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -399,7 +402,8 @@ class PayForTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -432,7 +436,8 @@ class PayForTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -465,7 +470,8 @@ class PayForTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -498,7 +504,8 @@ class PayForTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -531,7 +538,8 @@ class PayForTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -674,7 +682,8 @@ class PayForTest extends TestCase
         string $encodedRequestData,
         string $responseContent,
         array  $decodedResponse,
-        array  $order
+        array  $order,
+        string $paymentModel
     ): void
     {
         $this->serializerMock->expects(self::once())
@@ -701,12 +710,13 @@ class PayForTest extends TestCase
 
         $this->eventDispatcherMock->expects(self::once())
             ->method('dispatch')
-            ->with($this->callback(function ($dispatchedEvent) use ($txType, $requestData, $order) {
+            ->with($this->callback(function ($dispatchedEvent) use ($txType, $requestData, $order, $paymentModel) {
                 return $dispatchedEvent instanceof RequestDataPreparedEvent
                     && get_class($this->pos) === $dispatchedEvent->getGatewayClass()
                     && $txType === $dispatchedEvent->getTxType()
                     && $requestData === $dispatchedEvent->getRequestData()
                     && $order === $dispatchedEvent->getOrder()
+                    && $paymentModel === $dispatchedEvent->getPaymentModel()
                     ;
             }));
     }

--- a/tests/Unit/Gateways/PayForTest.php
+++ b/tests/Unit/Gateways/PayForTest.php
@@ -228,6 +228,7 @@ class PayForTest extends TestCase
                 'request-body',
                 'response-body',
                 $paymentResponse,
+                $order
             );
 
             $this->responseMapperMock->expects(self::once())
@@ -331,6 +332,7 @@ class PayForTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
+            $order
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -363,6 +365,7 @@ class PayForTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
+            $order
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -396,6 +399,7 @@ class PayForTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
+            $order
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -428,6 +432,7 @@ class PayForTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
+            $order
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -460,6 +465,7 @@ class PayForTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
+            $order
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -492,6 +498,7 @@ class PayForTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
+            $order
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -524,6 +531,7 @@ class PayForTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
+            $order
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -665,7 +673,8 @@ class PayForTest extends TestCase
         array  $requestData,
         string $encodedRequestData,
         string $responseContent,
-        array  $decodedResponse
+        array  $decodedResponse,
+        array  $order
     ): void
     {
         $this->serializerMock->expects(self::once())
@@ -692,11 +701,12 @@ class PayForTest extends TestCase
 
         $this->eventDispatcherMock->expects(self::once())
             ->method('dispatch')
-            ->with($this->callback(function ($dispatchedEvent) use ($txType, $requestData) {
+            ->with($this->callback(function ($dispatchedEvent) use ($txType, $requestData, $order) {
                 return $dispatchedEvent instanceof RequestDataPreparedEvent
                     && get_class($this->pos) === $dispatchedEvent->getGatewayClass()
                     && $txType === $dispatchedEvent->getTxType()
                     && $requestData === $dispatchedEvent->getRequestData()
+                    && $order === $dispatchedEvent->getOrder()
                     ;
             }));
     }

--- a/tests/Unit/Gateways/PosNetTest.php
+++ b/tests/Unit/Gateways/PosNetTest.php
@@ -172,7 +172,8 @@ class PosNetTest extends TestCase
             'request-body',
             'response-body',
             $responseData,
-            $order
+            $order,
+            PosInterface::MODEL_3D_SECURE
         );
 
         $this->requestMapperMock->expects(self::never())
@@ -287,24 +288,27 @@ class PosNetTest extends TestCase
                 ]
             );
 
+            $paymentModel = PosInterface::MODEL_3D_SECURE;
             $this->eventDispatcherMock->expects(self::exactly(2))
                 ->method('dispatch')
                 // could not find another way expect using deprecated withConsecutive() function
                 ->withConsecutive(
-                    [$this->callback(function ($dispatchedEvent) use ($txType, $resolveMerchantRequestData, $order) {
+                    [$this->callback(function ($dispatchedEvent) use ($txType, $resolveMerchantRequestData, $order, $paymentModel) {
                         return $dispatchedEvent instanceof RequestDataPreparedEvent
                             && get_class($this->pos) === $dispatchedEvent->getGatewayClass()
                             && $txType === $dispatchedEvent->getTxType()
                             && $resolveMerchantRequestData === $dispatchedEvent->getRequestData()
                             && $order === $dispatchedEvent->getOrder()
+                            && $paymentModel === $dispatchedEvent->getPaymentModel()
                             ;
                     })],
-                    [$this->callback(function ($dispatchedEvent) use ($txType, $create3DPaymentRequestData, $order) {
+                    [$this->callback(function ($dispatchedEvent) use ($txType, $create3DPaymentRequestData, $order, $paymentModel) {
                         return $dispatchedEvent instanceof RequestDataPreparedEvent
                             && get_class($this->pos) === $dispatchedEvent->getGatewayClass()
                             && $txType === $dispatchedEvent->getTxType()
                             && $create3DPaymentRequestData === $dispatchedEvent->getRequestData()
                             && $order === $dispatchedEvent->getOrder()
+                            && $paymentModel === $dispatchedEvent->getPaymentModel()
                             ;
                     })]
                 );
@@ -321,7 +325,8 @@ class PosNetTest extends TestCase
                 'resolveMerchantRequestData-body',
                 'resolveMerchantRequestData-body',
                 $resolveResponse,
-                $order
+                $order,
+                PosInterface::MODEL_3D_SECURE
             );
 
             $this->responseMapperMock->expects(self::once())
@@ -377,7 +382,8 @@ class PosNetTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -410,7 +416,8 @@ class PosNetTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -444,7 +451,8 @@ class PosNetTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -477,7 +485,8 @@ class PosNetTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -510,7 +519,8 @@ class PosNetTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -650,7 +660,8 @@ class PosNetTest extends TestCase
         string $encodedRequestData,
         string $responseContent,
         array  $decodedResponse,
-        array  $order
+        array  $order,
+        string $paymentModel
     ): void
     {
         $this->serializerMock->expects(self::once())
@@ -677,12 +688,13 @@ class PosNetTest extends TestCase
 
         $this->eventDispatcherMock->expects(self::once())
             ->method('dispatch')
-            ->with($this->callback(function ($dispatchedEvent) use ($txType, $requestData, $order) {
+            ->with($this->callback(function ($dispatchedEvent) use ($txType, $requestData, $order, $paymentModel) {
                 return $dispatchedEvent instanceof RequestDataPreparedEvent
                     && get_class($this->pos) === $dispatchedEvent->getGatewayClass()
                     && $txType === $dispatchedEvent->getTxType()
                     && $requestData === $dispatchedEvent->getRequestData()
                     && $order === $dispatchedEvent->getOrder()
+                    && $paymentModel === $dispatchedEvent->getPaymentModel()
                     ;
             }));
     }

--- a/tests/Unit/Gateways/PosNetTest.php
+++ b/tests/Unit/Gateways/PosNetTest.php
@@ -31,6 +31,7 @@ use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @covers \Mews\Pos\Gateways\PosNet
+ * @covers \Mews\Pos\Gateways\AbstractGateway
  */
 class PosNetTest extends TestCase
 {
@@ -148,43 +149,33 @@ class PosNetTest extends TestCase
      */
     public function testGet3DFormDataOosTransactionFail(): void
     {
+        $txType      = PosInterface::TX_TYPE_PAY_AUTH;
+        $requestData = ['request-data'];
         $this->expectException(Exception::class);
         $this->requestMapperMock->expects(self::once())
             ->method('create3DEnrollmentCheckRequestData')
-            ->with($this->pos->getAccount(), $this->order, PosInterface::TX_TYPE_PAY_AUTH, $this->card)
-            ->willReturn(['request-data']);
-
-        $this->serializerMock->expects(self::once())
-            ->method('encode')
-            ->with(['request-data'], PosInterface::TX_TYPE_PAY_AUTH)
-            ->willReturn('encoded-request-data');
-
-        $this->prepareClient(
-            $this->httpClientMock,
-            'response-content',
-            $this->config['gateway_endpoints']['payment_api'],
-            [
-                'headers' => [
-                    'Content-Type' => 'application/x-www-form-urlencoded',
-                ],
-                'body'    => \sprintf('xmldata=%s', 'encoded-request-data'),
-            ],
-        );
+            ->with($this->pos->getAccount(), $this->order, $txType, $this->card)
+            ->willReturn($requestData);
 
         $responseData = [
             'approved' => '0',
             'respCode' => '0003',
             'respText' => '148 MID,TID,IP HATALI:89.244.149.137',
         ];
-        $this->serializerMock->expects(self::once())
-            ->method('decode')
-            ->with('response-content', PosInterface::TX_TYPE_PAY_AUTH)
-            ->willReturn($responseData);
+
+        $this->configureClientResponse(
+            $txType,
+            $this->config['gateway_endpoints']['payment_api'],
+            $requestData,
+            'request-body',
+            'response-body',
+            $responseData,
+        );
 
         $this->requestMapperMock->expects(self::never())
             ->method('create3DFormData');
 
-        $this->pos->get3DFormData($this->order, PosInterface::MODEL_3D_SECURE, PosInterface::TX_TYPE_PAY_AUTH, $this->card);
+        $this->pos->get3DFormData($this->order, PosInterface::MODEL_3D_SECURE, $txType, $this->card);
     }
 
     /**
@@ -298,26 +289,13 @@ class PosNetTest extends TestCase
                 ->with($resolveResponse, $paymentResponse, $txType, $order)
                 ->willReturn($expectedResponse);
         } else {
-            $this->serializerMock->expects(self::once())
-                ->method('encode')
-                ->with($resolveMerchantRequestData, $txType)
-                ->willReturn('resolveMerchantRequestData-body');
-
-            $this->serializerMock->expects(self::once())
-                ->method('decode')
-                ->with('resolveMerchantRequestData-body', $txType)
-                ->willReturn($resolveResponse);
-
-            $this->prepareClient(
-                $this->httpClientMock,
-                'resolveMerchantRequestData-body',
+            $this->configureClientResponse(
+                $txType,
                 $this->config['gateway_endpoints']['payment_api'],
-                [
-                    'headers' => [
-                        'Content-Type' => 'application/x-www-form-urlencoded',
-                    ],
-                    'body'    => \sprintf('xmldata=%s', 'resolveMerchantRequestData-body'),
-                ],
+                $resolveMerchantRequestData,
+                'resolveMerchantRequestData-body',
+                'resolveMerchantRequestData-body',
+                $resolveResponse,
             );
 
             $this->responseMapperMock->expects(self::once())
@@ -357,37 +335,27 @@ class PosNetTest extends TestCase
      */
     public function testMakeRegularPayment(array $order, string $txType, string $apiUrl): void
     {
-        $account = $this->pos->getAccount();
-        $card    = $this->card;
+        $account     = $this->pos->getAccount();
+        $card        = $this->card;
+        $requestData = ['createNonSecurePaymentRequestData'];
         $this->requestMapperMock->expects(self::once())
             ->method('createNonSecurePaymentRequestData')
             ->with($account, $order, $txType, $card)
-            ->willReturn(['createNonSecurePaymentRequestData']);
-        $this->prepareClient(
-            $this->httpClientMock,
-            'response-body',
+            ->willReturn($requestData);
+
+        $decodedResponse = ['decodedData'];
+        $this->configureClientResponse(
+            $txType,
             $apiUrl,
-            [
-                'body'    => 'xmldata=request-body',
-                'headers' => [
-                    'Content-Type' => 'application/x-www-form-urlencoded',
-                ],
-            ],
+            $requestData,
+            'request-body',
+            'response-body',
+            $decodedResponse,
         );
-
-        $this->serializerMock->expects(self::once())
-            ->method('encode')
-            ->with(['createNonSecurePaymentRequestData'], $txType)
-            ->willReturn('request-body');
-
-        $this->serializerMock->expects(self::once())
-            ->method('decode')
-            ->with('response-body', $txType)
-            ->willReturn(['paymentResponse']);
 
         $this->responseMapperMock->expects(self::once())
             ->method('mapPaymentResponse')
-            ->with(['paymentResponse'], $txType, $order)
+            ->with($decodedResponse, $txType, $order)
             ->willReturn(['result']);
 
         $this->pos->makeRegularPayment($order, $card, $txType);
@@ -398,39 +366,28 @@ class PosNetTest extends TestCase
      */
     public function testMakeRegularPostAuthPayment(array $order, string $apiUrl): void
     {
-        $account = $this->pos->getAccount();
-        $txType  = PosInterface::TX_TYPE_PAY_POST_AUTH;
+        $account     = $this->pos->getAccount();
+        $txType      = PosInterface::TX_TYPE_PAY_POST_AUTH;
+        $requestData = ['createNonSecurePostAuthPaymentRequestData'];
 
         $this->requestMapperMock->expects(self::once())
             ->method('createNonSecurePostAuthPaymentRequestData')
             ->with($account, $order)
-            ->willReturn(['createNonSecurePostAuthPaymentRequestData']);
+            ->willReturn($requestData);
 
-        $this->serializerMock->expects(self::once())
-            ->method('encode')
-            ->with(['createNonSecurePostAuthPaymentRequestData'], $txType)
-            ->willReturn('request-body');
-
-        $this->prepareClient(
-            $this->httpClientMock,
-            'response-body',
+        $decodedResponse = ['decodedData'];
+        $this->configureClientResponse(
+            $txType,
             $apiUrl,
-            [
-                'body'    => 'xmldata=request-body',
-                'headers' => [
-                    'Content-Type' => 'application/x-www-form-urlencoded',
-                ],
-            ],
+            $requestData,
+            'request-body',
+            'response-body',
+            $decodedResponse,
         );
-
-        $this->serializerMock->expects(self::once())
-            ->method('decode')
-            ->with('response-body', $txType)
-            ->willReturn(['paymentResponse']);
 
         $this->responseMapperMock->expects(self::once())
             ->method('mapPaymentResponse')
-            ->with(['paymentResponse'], $txType, $order)
+            ->with($decodedResponse, $txType, $order)
             ->willReturn(['result']);
 
         $this->pos->makeRegularPostPayment($order);
@@ -442,40 +399,28 @@ class PosNetTest extends TestCase
      */
     public function testStatusRequest(array $order, string $apiUrl): void
     {
-        $account = $this->pos->getAccount();
-        $txType  = PosInterface::TX_TYPE_STATUS;
+        $account     = $this->pos->getAccount();
+        $txType      = PosInterface::TX_TYPE_STATUS;
+        $requestData = ['createStatusRequestData'];
 
         $this->requestMapperMock->expects(self::once())
             ->method('createStatusRequestData')
             ->with($account, $order)
-            ->willReturn(['createStatusRequestData']);
+            ->willReturn($requestData);
 
-        $this->serializerMock->expects(self::once())
-            ->method('encode')
-            ->with(['createStatusRequestData'], $txType)
-            ->willReturn('request-body');
-
-        $this->prepareClient(
-            $this->httpClientMock,
-            'response-body',
+        $decodedResponse = ['decodedData'];
+        $this->configureClientResponse(
+            $txType,
             $apiUrl,
-            [
-                'body'    => 'xmldata=request-body',
-                'headers' => [
-                    'Content-Type' => 'application/x-www-form-urlencoded',
-                ],
-            ],
+            $requestData,
+            'request-body',
+            'response-body',
+            $decodedResponse,
         );
-
-
-        $this->serializerMock->expects(self::once())
-            ->method('decode')
-            ->with('response-body', $txType)
-            ->willReturn(['decodedResponse']);
 
         $this->responseMapperMock->expects(self::once())
             ->method('mapStatusResponse')
-            ->with(['decodedResponse'])
+            ->with($decodedResponse)
             ->willReturn(['result']);
 
         $this->pos->status($order);
@@ -486,39 +431,28 @@ class PosNetTest extends TestCase
      */
     public function testCancelRequest(array $order, string $apiUrl): void
     {
-        $account = $this->pos->getAccount();
-        $txType  = PosInterface::TX_TYPE_CANCEL;
+        $account     = $this->pos->getAccount();
+        $txType      = PosInterface::TX_TYPE_CANCEL;
+        $requestData = ['createCancelRequestData'];
 
         $this->requestMapperMock->expects(self::once())
             ->method('createCancelRequestData')
             ->with($account, $order)
-            ->willReturn(['createCancelRequestData']);
+            ->willReturn($requestData);
 
-        $this->serializerMock->expects(self::once())
-            ->method('encode')
-            ->with(['createCancelRequestData'], $txType)
-            ->willReturn('request-body');
-
-        $this->prepareClient(
-            $this->httpClientMock,
-            'response-body',
+        $decodedResponse = ['decodedData'];
+        $this->configureClientResponse(
+            $txType,
             $apiUrl,
-            [
-                'body'    => 'xmldata=request-body',
-                'headers' => [
-                    'Content-Type' => 'application/x-www-form-urlencoded',
-                ],
-            ],
+            $requestData,
+            'request-body',
+            'response-body',
+            $decodedResponse,
         );
-
-        $this->serializerMock->expects(self::once())
-            ->method('decode')
-            ->with('response-body', $txType)
-            ->willReturn(['decodedResponse']);
 
         $this->responseMapperMock->expects(self::once())
             ->method('mapCancelResponse')
-            ->with(['decodedResponse'])
+            ->with($decodedResponse)
             ->willReturn(['result']);
 
         $this->pos->cancel($order);
@@ -529,39 +463,28 @@ class PosNetTest extends TestCase
      */
     public function testRefundRequest(array $order, string $apiUrl): void
     {
-        $account = $this->pos->getAccount();
-        $txType  = PosInterface::TX_TYPE_REFUND;
+        $account     = $this->pos->getAccount();
+        $txType      = PosInterface::TX_TYPE_REFUND;
+        $requestData = ['createRefundRequestData'];
 
         $this->requestMapperMock->expects(self::once())
             ->method('createRefundRequestData')
             ->with($account, $order)
-            ->willReturn(['createRefundRequestData']);
+            ->willReturn($requestData);
 
-        $this->serializerMock->expects(self::once())
-            ->method('encode')
-            ->with(['createRefundRequestData'], $txType)
-            ->willReturn('request-body');
-
-        $this->prepareClient(
-            $this->httpClientMock,
-            'response-body',
+        $decodedResponse = ['decodedData'];
+        $this->configureClientResponse(
+            $txType,
             $apiUrl,
-            [
-                'body'    => 'xmldata=request-body',
-                'headers' => [
-                    'Content-Type' => 'application/x-www-form-urlencoded',
-                ],
-            ],
+            $requestData,
+            'request-body',
+            'response-body',
+            $decodedResponse,
         );
-
-        $this->serializerMock->expects(self::once())
-            ->method('decode')
-            ->with('response-body', $txType)
-            ->willReturn(['decodedResponse']);
 
         $this->responseMapperMock->expects(self::once())
             ->method('mapRefundResponse')
-            ->with(['decodedResponse'])
+            ->with($decodedResponse)
             ->willReturn(['result']);
 
         $this->pos->refund($order);
@@ -689,27 +612,35 @@ class PosNetTest extends TestCase
         ];
     }
 
-    public static function historyRequestDataProvider(): array
+    private function configureClientResponse(
+        string $txType,
+        string $apiUrl,
+        array  $requestData,
+        string $encodedRequestData,
+        string $responseContent,
+        array  $decodedResponse
+    ): void
     {
-        return [
-            [
-                'order'   => [
-                    'id' => '2020110828BC',
-                ],
-                'api_url' => 'https://setmpos.ykb.com/PosnetWebService/XML',
-            ],
-        ];
-    }
+        $this->serializerMock->expects(self::once())
+            ->method('encode')
+            ->with($requestData, $txType)
+            ->willReturn($encodedRequestData);
 
-    public static function orderHistoryRequestDataProvider(): array
-    {
-        return [
+        $this->serializerMock->expects(self::once())
+            ->method('decode')
+            ->with($responseContent, $txType)
+            ->willReturn($decodedResponse);
+
+        $this->prepareClient(
+            $this->httpClientMock,
+            $responseContent,
+            $apiUrl,
             [
-                'order'   => [
-                    'id' => '2020110828BC',
+                'headers' => [
+                    'Content-Type' => 'application/x-www-form-urlencoded',
                 ],
-                'api_url' => 'https://setmpos.ykb.com/PosnetWebService/XML',
+                'body'    => \sprintf('xmldata=%s', $encodedRequestData),
             ],
-        ];
+        );
     }
 }

--- a/tests/Unit/Gateways/PosNetV1PosTest.php
+++ b/tests/Unit/Gateways/PosNetV1PosTest.php
@@ -11,6 +11,7 @@ use Mews\Pos\DataMapper\RequestDataMapper\RequestDataMapperInterface;
 use Mews\Pos\DataMapper\ResponseDataMapper\ResponseDataMapperInterface;
 use Mews\Pos\Entity\Account\PosNetAccount;
 use Mews\Pos\Entity\Card\CreditCardInterface;
+use Mews\Pos\Event\RequestDataPreparedEvent;
 use Mews\Pos\Exceptions\UnsupportedPaymentModelException;
 use Mews\Pos\Exceptions\UnsupportedTransactionTypeException;
 use Mews\Pos\Factory\AccountFactory;
@@ -620,5 +621,14 @@ class PosNetV1PosTest extends TestCase
                 'body'    => $encodedRequestData,
             ],
         );
+
+        $this->eventDispatcherMock->expects(self::once())
+            ->method('dispatch')
+            ->with($this->callback(function ($dispatchedEvent) use ($txType, $requestData) {
+                return $dispatchedEvent instanceof RequestDataPreparedEvent
+                    && get_class($this->pos) === $dispatchedEvent->getGatewayClass()
+                    && $txType === $dispatchedEvent->getTxType()
+                    && $requestData === $dispatchedEvent->getRequestData();
+            }));
     }
 }

--- a/tests/Unit/Gateways/PosNetV1PosTest.php
+++ b/tests/Unit/Gateways/PosNetV1PosTest.php
@@ -221,6 +221,7 @@ class PosNetV1PosTest extends TestCase
                 'request-body',
                 'response-body',
                 $paymentResponse,
+                $order
             );
 
             $this->responseMapperMock->expects(self::once())
@@ -292,6 +293,7 @@ class PosNetV1PosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
+            $order
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -329,6 +331,7 @@ class PosNetV1PosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
+            $order
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -367,6 +370,7 @@ class PosNetV1PosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
+            $order
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -404,6 +408,7 @@ class PosNetV1PosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
+            $order
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -441,6 +446,7 @@ class PosNetV1PosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
+            $order
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -597,7 +603,8 @@ class PosNetV1PosTest extends TestCase
         array  $requestData,
         string $encodedRequestData,
         string $responseContent,
-        array  $decodedResponse
+        array  $decodedResponse,
+        array  $order
     ): void
     {
         $this->serializerMock->expects(self::once())
@@ -624,11 +631,13 @@ class PosNetV1PosTest extends TestCase
 
         $this->eventDispatcherMock->expects(self::once())
             ->method('dispatch')
-            ->with($this->callback(function ($dispatchedEvent) use ($txType, $requestData) {
+            ->with($this->callback(function ($dispatchedEvent) use ($txType, $requestData, $order) {
                 return $dispatchedEvent instanceof RequestDataPreparedEvent
                     && get_class($this->pos) === $dispatchedEvent->getGatewayClass()
                     && $txType === $dispatchedEvent->getTxType()
-                    && $requestData === $dispatchedEvent->getRequestData();
+                    && $requestData === $dispatchedEvent->getRequestData()
+                    && $order === $dispatchedEvent->getOrder()
+                    ;
             }));
     }
 }

--- a/tests/Unit/Gateways/PosNetV1PosTest.php
+++ b/tests/Unit/Gateways/PosNetV1PosTest.php
@@ -221,7 +221,8 @@ class PosNetV1PosTest extends TestCase
                 'request-body',
                 'response-body',
                 $paymentResponse,
-                $order
+                $order,
+                PosInterface::MODEL_3D_SECURE
             );
 
             $this->responseMapperMock->expects(self::once())
@@ -293,7 +294,8 @@ class PosNetV1PosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -331,7 +333,8 @@ class PosNetV1PosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -370,7 +373,8 @@ class PosNetV1PosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -408,7 +412,8 @@ class PosNetV1PosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -446,7 +451,8 @@ class PosNetV1PosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -604,7 +610,8 @@ class PosNetV1PosTest extends TestCase
         string $encodedRequestData,
         string $responseContent,
         array  $decodedResponse,
-        array  $order
+        array  $order,
+        string $paymentModel
     ): void
     {
         $this->serializerMock->expects(self::once())
@@ -631,12 +638,13 @@ class PosNetV1PosTest extends TestCase
 
         $this->eventDispatcherMock->expects(self::once())
             ->method('dispatch')
-            ->with($this->callback(function ($dispatchedEvent) use ($txType, $requestData, $order) {
+            ->with($this->callback(function ($dispatchedEvent) use ($txType, $requestData, $order, $paymentModel) {
                 return $dispatchedEvent instanceof RequestDataPreparedEvent
                     && get_class($this->pos) === $dispatchedEvent->getGatewayClass()
                     && $txType === $dispatchedEvent->getTxType()
                     && $requestData === $dispatchedEvent->getRequestData()
                     && $order === $dispatchedEvent->getOrder()
+                    && $paymentModel === $dispatchedEvent->getPaymentModel()
                     ;
             }));
     }

--- a/tests/Unit/Gateways/ToslaPosTest.php
+++ b/tests/Unit/Gateways/ToslaPosTest.php
@@ -271,6 +271,7 @@ class ToslaPosTest extends TestCase
             $encodedRequestData,
             $responseData,
             $decodedResponseData,
+            $order
         );
 
         $this->requestMapperMock->expects(self::once())
@@ -322,7 +323,8 @@ class ToslaPosTest extends TestCase
             $requestData,
             $encodedRequest,
             $responseContent,
-            $decodedResponse
+            $decodedResponse,
+            $order
         );
 
         $this->pos->status($order);
@@ -362,7 +364,8 @@ class ToslaPosTest extends TestCase
             $requestData,
             $encodedRequest,
             $responseContent,
-            $decodedResponse
+            $decodedResponse,
+            $order
         );
 
         $this->pos->cancel($order);
@@ -401,7 +404,8 @@ class ToslaPosTest extends TestCase
             $requestData,
             $encodedRequest,
             $responseContent,
-            $decodedResponse
+            $decodedResponse,
+            $order
         );
 
         $this->pos->refund($order);
@@ -449,7 +453,8 @@ class ToslaPosTest extends TestCase
             $requestData,
             $encodedRequest,
             $responseContent,
-            $decodedResponse
+            $decodedResponse,
+            $order
         );
 
         $this->pos->orderHistory($order);
@@ -585,6 +590,7 @@ class ToslaPosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
+            $order
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -617,6 +623,7 @@ class ToslaPosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
+            $order
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -650,6 +657,7 @@ class ToslaPosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
+            $order
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -682,6 +690,7 @@ class ToslaPosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
+            $order
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -714,6 +723,7 @@ class ToslaPosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
+            $order
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -849,7 +859,8 @@ class ToslaPosTest extends TestCase
         array  $requestData,
         string $encodedRequestData,
         string $responseContent,
-        array  $decodedResponse
+        array  $decodedResponse,
+        array  $order
     ): void
     {
         $this->serializerMock->expects(self::once())
@@ -875,11 +886,12 @@ class ToslaPosTest extends TestCase
 
         $this->eventDispatcherMock->expects(self::once())
             ->method('dispatch')
-            ->with($this->callback(function ($dispatchedEvent) use ($txType, $requestData) {
+            ->with($this->callback(function ($dispatchedEvent) use ($txType, $requestData, $order) {
                 return $dispatchedEvent instanceof RequestDataPreparedEvent
                     && get_class($this->pos) === $dispatchedEvent->getGatewayClass()
                     && $txType === $dispatchedEvent->getTxType()
                     && $requestData === $dispatchedEvent->getRequestData()
+                    && $order === $dispatchedEvent->getOrder()
                     ;
             }));
     }

--- a/tests/Unit/Gateways/ToslaPosTest.php
+++ b/tests/Unit/Gateways/ToslaPosTest.php
@@ -271,7 +271,8 @@ class ToslaPosTest extends TestCase
             $encodedRequestData,
             $responseData,
             $decodedResponseData,
-            $order
+            $order,
+            $paymentModel
         );
 
         $this->requestMapperMock->expects(self::once())
@@ -324,7 +325,8 @@ class ToslaPosTest extends TestCase
             $encodedRequest,
             $responseContent,
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->pos->status($order);
@@ -365,7 +367,8 @@ class ToslaPosTest extends TestCase
             $encodedRequest,
             $responseContent,
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->pos->cancel($order);
@@ -405,7 +408,8 @@ class ToslaPosTest extends TestCase
             $encodedRequest,
             $responseContent,
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->pos->refund($order);
@@ -454,7 +458,8 @@ class ToslaPosTest extends TestCase
             $encodedRequest,
             $responseContent,
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->pos->orderHistory($order);
@@ -590,7 +595,8 @@ class ToslaPosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -623,7 +629,8 @@ class ToslaPosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -657,7 +664,8 @@ class ToslaPosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -690,7 +698,8 @@ class ToslaPosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -723,7 +732,8 @@ class ToslaPosTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -860,7 +870,8 @@ class ToslaPosTest extends TestCase
         string $encodedRequestData,
         string $responseContent,
         array  $decodedResponse,
-        array  $order
+        array  $order,
+        string $paymentModel
     ): void
     {
         $this->serializerMock->expects(self::once())
@@ -886,12 +897,13 @@ class ToslaPosTest extends TestCase
 
         $this->eventDispatcherMock->expects(self::once())
             ->method('dispatch')
-            ->with($this->callback(function ($dispatchedEvent) use ($txType, $requestData, $order) {
+            ->with($this->callback(function ($dispatchedEvent) use ($txType, $requestData, $order, $paymentModel) {
                 return $dispatchedEvent instanceof RequestDataPreparedEvent
                     && get_class($this->pos) === $dispatchedEvent->getGatewayClass()
                     && $txType === $dispatchedEvent->getTxType()
                     && $requestData === $dispatchedEvent->getRequestData()
                     && $order === $dispatchedEvent->getOrder()
+                    && $paymentModel === $dispatchedEvent->getPaymentModel()
                     ;
             }));
     }

--- a/tests/Unit/Gateways/ToslaPosTest.php
+++ b/tests/Unit/Gateways/ToslaPosTest.php
@@ -311,10 +311,6 @@ class ToslaPosTest extends TestCase
             ->with($account, $order)
             ->willReturn($requestData);
 
-        $this->eventDispatcherMock->expects(self::once())
-            ->method('dispatch')
-            ->with($this->logicalAnd($this->isInstanceOf(RequestDataPreparedEvent::class)));
-
         $this->responseMapperMock->expects(self::once())
             ->method('mapStatusResponse')
             ->with($decodedResponse)
@@ -355,10 +351,6 @@ class ToslaPosTest extends TestCase
             ->with($this->pos->getAccount(), $order)
             ->willReturn($requestData);
 
-        $this->eventDispatcherMock->expects(self::once())
-            ->method('dispatch')
-            ->with($this->logicalAnd($this->isInstanceOf(RequestDataPreparedEvent::class)));
-
         $this->responseMapperMock->expects(self::once())
             ->method('mapCancelResponse')
             ->with($decodedResponse)
@@ -397,10 +389,6 @@ class ToslaPosTest extends TestCase
             ->method('createRefundRequestData')
             ->with($this->pos->getAccount(), $order)
             ->willReturn($requestData);
-
-        $this->eventDispatcherMock->expects(self::once())
-            ->method('dispatch')
-            ->with($this->logicalAnd($this->isInstanceOf(RequestDataPreparedEvent::class)));
 
         $this->responseMapperMock->expects(self::once())
             ->method('mapRefundResponse')
@@ -449,10 +437,6 @@ class ToslaPosTest extends TestCase
             ->method('createOrderHistoryRequestData')
             ->with($account, $order)
             ->willReturn($requestData);
-
-        $this->eventDispatcherMock->expects(self::once())
-            ->method('dispatch')
-            ->with($this->logicalAnd($this->isInstanceOf(RequestDataPreparedEvent::class)));
 
         $this->responseMapperMock->expects(self::once())
             ->method('mapOrderHistoryResponse')
@@ -888,5 +872,15 @@ class ToslaPosTest extends TestCase
                 'body'    => $encodedRequestData,
             ],
         );
+
+        $this->eventDispatcherMock->expects(self::once())
+            ->method('dispatch')
+            ->with($this->callback(function ($dispatchedEvent) use ($txType, $requestData) {
+                return $dispatchedEvent instanceof RequestDataPreparedEvent
+                    && get_class($this->pos) === $dispatchedEvent->getGatewayClass()
+                    && $txType === $dispatchedEvent->getTxType()
+                    && $requestData === $dispatchedEvent->getRequestData()
+                    ;
+            }));
     }
 }

--- a/tests/Unit/Gateways/VakifKatilimTest.php
+++ b/tests/Unit/Gateways/VakifKatilimTest.php
@@ -180,6 +180,7 @@ class VakifKatilimTest extends TestCase
         $paymentModel = PosInterface::MODEL_3D_SECURE;
         $card         = $this->card;
         $requestData  = ['form-data'];
+        $order        = $this->order;
 
         $decodedResponse = ['form_inputs' => ['form-inputs'], 'gateway' => 'form-action-url'];
         $this->configureClientResponse(
@@ -189,6 +190,7 @@ class VakifKatilimTest extends TestCase
             'request-body',
             'bank-api-html-response',
             $decodedResponse,
+            $order
         );
 
         $this->requestMapperMock->expects(self::once())
@@ -213,7 +215,7 @@ class VakifKatilimTest extends TestCase
                 $card
             )
             ->willReturn(['3d-form-data']);
-        $result = $this->pos->get3DFormData($this->order, $paymentModel, $txType, $card);
+        $result = $this->pos->get3DFormData($order, $paymentModel, $txType, $card);
 
         $this->assertSame(['3d-form-data'], $result);
     }
@@ -283,6 +285,7 @@ class VakifKatilimTest extends TestCase
                 'request-body',
                 'response-body',
                 $paymentResponse,
+                $order
             );
 
             $this->responseMapperMock->expects(self::once())
@@ -366,6 +369,7 @@ class VakifKatilimTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
+            $order
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -398,6 +402,7 @@ class VakifKatilimTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
+            $order
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -431,6 +436,7 @@ class VakifKatilimTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
+            $order
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -463,6 +469,7 @@ class VakifKatilimTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
+            $order
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -495,6 +502,7 @@ class VakifKatilimTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
+            $order
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -528,6 +536,7 @@ class VakifKatilimTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
+            $order
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -560,6 +569,7 @@ class VakifKatilimTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
+            $order
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -780,7 +790,8 @@ class VakifKatilimTest extends TestCase
         array  $requestData,
         string $encodedRequestData,
         string $responseContent,
-        array  $decodedResponse
+        array  $decodedResponse,
+        array  $order
     ): void
     {
         $this->serializerMock->expects(self::once())
@@ -806,11 +817,12 @@ class VakifKatilimTest extends TestCase
 
         $this->eventDispatcherMock->expects(self::once())
             ->method('dispatch')
-            ->with($this->callback(function ($dispatchedEvent) use ($txType, $requestData) {
+            ->with($this->callback(function ($dispatchedEvent) use ($txType, $requestData, $order) {
                 return $dispatchedEvent instanceof RequestDataPreparedEvent
                     && get_class($this->pos) === $dispatchedEvent->getGatewayClass()
                     && $txType === $dispatchedEvent->getTxType()
                     && $requestData === $dispatchedEvent->getRequestData()
+                    && $order === $dispatchedEvent->getOrder()
                     ;
             }));
     }

--- a/tests/Unit/Gateways/VakifKatilimTest.php
+++ b/tests/Unit/Gateways/VakifKatilimTest.php
@@ -28,6 +28,7 @@ use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @covers \Mews\Pos\Gateways\VakifKatilimPos
+ * @covers \Mews\Pos\Gateways\AbstractGateway
  */
 class VakifKatilimTest extends TestCase
 {
@@ -174,30 +175,19 @@ class VakifKatilimTest extends TestCase
      */
     public function testGetCommon3DFormDataSuccessResponse(): void
     {
-        $response     = 'bank-api-html-response';
         $txType       = PosInterface::TX_TYPE_PAY_AUTH;
         $paymentModel = PosInterface::MODEL_3D_SECURE;
         $card         = $this->card;
+        $requestData  = ['form-data'];
 
-        $this->serializerMock->expects(self::once())
-            ->method('encode')
-            ->with(['form-data'], $txType)
-            ->willReturn('encoded-request-data');
-
-        $this->serializerMock->expects(self::once())
-            ->method('decode')
-            ->with($response, $txType)
-            ->willReturn(['form_inputs' => ['form-inputs'], 'gateway' => 'form-action-url']);
-        $this->prepareClient(
-            $this->httpClientMock,
-            $response,
+        $decodedResponse = ['form_inputs' => ['form-inputs'], 'gateway' => 'form-action-url'];
+        $this->configureClientResponse(
+            $txType,
             'https://boa.vakifkatilim.com.tr/VirtualPOS.Gateway/Home/ThreeDModelPayGate',
-            [
-                'body'    => 'encoded-request-data',
-                'headers' => [
-                    'Content-Type' => 'text/xml; charset=UTF-8',
-                ],
-            ],
+            $requestData,
+            'request-body',
+            'bank-api-html-response',
+            $decodedResponse,
         );
 
         $this->eventDispatcherMock->expects(self::once())
@@ -212,7 +202,7 @@ class VakifKatilimTest extends TestCase
                 $txType,
                 $card
             )
-            ->willReturn(['form-data']);
+            ->willReturn($requestData);
 
         $this->requestMapperMock->expects(self::once())
             ->method('create3DFormData')
@@ -282,38 +272,20 @@ class VakifKatilimTest extends TestCase
             'create3DPaymentRequestData',
         ];
 
-
         if ($is3DSuccess) {
             $this->requestMapperMock->expects(self::once())
                 ->method('create3DPaymentRequestData')
                 ->with($this->account, $order, $txType, $request->request->all())
                 ->willReturn($create3DPaymentRequestData);
-            $this->prepareClient(
-                $this->httpClientMock,
-                'response-body',
+
+            $this->configureClientResponse(
+                $txType,
                 'https://boa.vakifkatilim.com.tr/VirtualPOS.Gateway/Home/ThreeDModelProvisionGate',
-                [
-                    'body'    => 'request-body',
-                    'headers' => [
-                        'Content-Type' => 'text/xml; charset=UTF-8',
-                    ],
-                ]
+                $create3DPaymentRequestData,
+                'request-body',
+                'response-body',
+                $paymentResponse,
             );
-
-            $this->serializerMock->expects(self::once())
-                ->method('encode')
-                ->with($create3DPaymentRequestData, $txType)
-                ->willReturn('request-body');
-
-            $this->serializerMock->expects(self::exactly(1))
-                ->method('decode')
-                ->willReturnMap([
-                    [
-                        'response-body',
-                        $txType,
-                        $paymentResponse,
-                    ],
-                ]);
 
             $this->responseMapperMock->expects(self::once())
                 ->method('map3DPaymentData')
@@ -332,6 +304,8 @@ class VakifKatilimTest extends TestCase
                 ->method('decode')
                 ->with(urldecode($request->request->get('AuthenticationResponse')), $txType)
                 ->willReturn($request->request->all());
+            $this->eventDispatcherMock->expects(self::never())
+                ->method('dispatch');
         }
 
         $this->pos->make3DPayment($request, $order, $txType);
@@ -378,37 +352,27 @@ class VakifKatilimTest extends TestCase
      */
     public function testMakeRegularPayment(array $order, string $txType, string $apiUrl): void
     {
-        $account = $this->pos->getAccount();
-        $card    = $this->card;
+        $account     = $this->pos->getAccount();
+        $card        = $this->card;
+        $requestData = ['createNonSecurePaymentRequestData'];
         $this->requestMapperMock->expects(self::once())
             ->method('createNonSecurePaymentRequestData')
             ->with($account, $order, $txType, $card)
-            ->willReturn(['createNonSecurePaymentRequestData']);
-        $this->prepareClient(
-            $this->httpClientMock,
-            'response-body',
+            ->willReturn($requestData);
+
+        $decodedResponse = ['decodedData'];
+        $this->configureClientResponse(
+            $txType,
             $apiUrl,
-            [
-                'body'    => 'request-body',
-                'headers' => [
-                    'Content-Type' => 'text/xml; charset=UTF-8',
-                ],
-            ]
+            $requestData,
+            'request-body',
+            'response-body',
+            $decodedResponse,
         );
-
-        $this->serializerMock->expects(self::once())
-            ->method('encode')
-            ->with(['createNonSecurePaymentRequestData'], $txType)
-            ->willReturn('request-body');
-
-        $this->serializerMock->expects(self::once())
-            ->method('decode')
-            ->with('response-body', $txType)
-            ->willReturn(['paymentResponse']);
 
         $this->responseMapperMock->expects(self::once())
             ->method('mapPaymentResponse')
-            ->with(['paymentResponse'], $txType, $order)
+            ->with($decodedResponse, $txType, $order)
             ->willReturn(['result']);
 
         $this->pos->makeRegularPayment($order, $card, $txType);
@@ -419,39 +383,28 @@ class VakifKatilimTest extends TestCase
      */
     public function testMakeRegularPostAuthPayment(array $order, string $apiUrl): void
     {
-        $account = $this->pos->getAccount();
-        $txType  = PosInterface::TX_TYPE_PAY_POST_AUTH;
+        $account     = $this->pos->getAccount();
+        $txType      = PosInterface::TX_TYPE_PAY_POST_AUTH;
+        $requestData = ['createNonSecurePostAuthPaymentRequestData'];
 
         $this->requestMapperMock->expects(self::once())
             ->method('createNonSecurePostAuthPaymentRequestData')
             ->with($account, $order)
-            ->willReturn(['createNonSecurePostAuthPaymentRequestData']);
+            ->willReturn($requestData);
 
-        $this->serializerMock->expects(self::once())
-            ->method('encode')
-            ->with(['createNonSecurePostAuthPaymentRequestData'], $txType)
-            ->willReturn('request-body');
-
-        $this->prepareClient(
-            $this->httpClientMock,
-            'response-body',
+        $decodedResponse = ['decodedData'];
+        $this->configureClientResponse(
+            $txType,
             $apiUrl,
-            [
-                'body'    => 'request-body',
-                'headers' => [
-                    'Content-Type' => 'text/xml; charset=UTF-8',
-                ],
-            ]
+            $requestData,
+            'request-body',
+            'response-body',
+            $decodedResponse,
         );
-
-        $this->serializerMock->expects(self::once())
-            ->method('decode')
-            ->with('response-body', $txType)
-            ->willReturn(['paymentResponse']);
 
         $this->responseMapperMock->expects(self::once())
             ->method('mapPaymentResponse')
-            ->with(['paymentResponse'], $txType, $order)
+            ->with($decodedResponse, $txType, $order)
             ->willReturn(['result']);
 
         $this->pos->makeRegularPostPayment($order);
@@ -463,40 +416,28 @@ class VakifKatilimTest extends TestCase
      */
     public function testStatusRequest(array $order, string $apiUrl): void
     {
-        $account = $this->pos->getAccount();
-        $txType  = PosInterface::TX_TYPE_STATUS;
+        $account     = $this->pos->getAccount();
+        $txType      = PosInterface::TX_TYPE_STATUS;
+        $requestData = ['createStatusRequestData'];
 
         $this->requestMapperMock->expects(self::once())
             ->method('createStatusRequestData')
             ->with($account, $order)
-            ->willReturn(['createStatusRequestData']);
+            ->willReturn($requestData);
 
-        $this->serializerMock->expects(self::once())
-            ->method('encode')
-            ->with(['createStatusRequestData'], $txType)
-            ->willReturn('request-body');
-
-        $this->prepareClient(
-            $this->httpClientMock,
-            'response-body',
+        $decodedResponse = ['decodedData'];
+        $this->configureClientResponse(
+            $txType,
             $apiUrl,
-            [
-                'body'    => 'request-body',
-                'headers' => [
-                    'Content-Type' => 'text/xml; charset=UTF-8',
-                ],
-            ]
+            $requestData,
+            'request-body',
+            'response-body',
+            $decodedResponse,
         );
-
-
-        $this->serializerMock->expects(self::once())
-            ->method('decode')
-            ->with('response-body', $txType)
-            ->willReturn(['decodedResponse']);
 
         $this->responseMapperMock->expects(self::once())
             ->method('mapStatusResponse')
-            ->with(['decodedResponse'])
+            ->with($decodedResponse)
             ->willReturn(['result']);
 
         $this->pos->status($order);
@@ -507,39 +448,28 @@ class VakifKatilimTest extends TestCase
      */
     public function testCancelRequest(array $order, string $apiUrl): void
     {
-        $account = $this->pos->getAccount();
-        $txType  = PosInterface::TX_TYPE_CANCEL;
+        $account     = $this->pos->getAccount();
+        $txType      = PosInterface::TX_TYPE_CANCEL;
+        $requestData = ['createCancelRequestData'];
 
         $this->requestMapperMock->expects(self::once())
             ->method('createCancelRequestData')
             ->with($account, $order)
-            ->willReturn(['createCancelRequestData']);
+            ->willReturn($requestData);
 
-        $this->serializerMock->expects(self::once())
-            ->method('encode')
-            ->with(['createCancelRequestData'], $txType)
-            ->willReturn('request-body');
-
-        $this->prepareClient(
-            $this->httpClientMock,
-            'response-body',
+        $decodedResponse = ['decodedData'];
+        $this->configureClientResponse(
+            $txType,
             $apiUrl,
-            [
-                'body'    => 'request-body',
-                'headers' => [
-                    'Content-Type' => 'text/xml; charset=UTF-8',
-                ],
-            ]
+            $requestData,
+            'request-body',
+            'response-body',
+            $decodedResponse,
         );
-
-        $this->serializerMock->expects(self::once())
-            ->method('decode')
-            ->with('response-body', $txType)
-            ->willReturn(['decodedResponse']);
 
         $this->responseMapperMock->expects(self::once())
             ->method('mapCancelResponse')
-            ->with(['decodedResponse'])
+            ->with($decodedResponse)
             ->willReturn(['result']);
 
         $this->pos->cancel($order);
@@ -550,39 +480,28 @@ class VakifKatilimTest extends TestCase
      */
     public function testRefundRequest(array $order, string $apiUrl): void
     {
-        $account = $this->pos->getAccount();
-        $txType  = PosInterface::TX_TYPE_REFUND;
+        $account     = $this->pos->getAccount();
+        $txType      = PosInterface::TX_TYPE_REFUND;
+        $requestData = ['createRefundRequestData'];
 
         $this->requestMapperMock->expects(self::once())
             ->method('createRefundRequestData')
             ->with($account, $order)
-            ->willReturn(['createRefundRequestData']);
+            ->willReturn($requestData);
 
-        $this->serializerMock->expects(self::once())
-            ->method('encode')
-            ->with(['createRefundRequestData'], $txType)
-            ->willReturn('request-body');
-
-        $this->prepareClient(
-            $this->httpClientMock,
-            'response-body',
+        $decodedResponse = ['decodedData'];
+        $this->configureClientResponse(
+            $txType,
             $apiUrl,
-            [
-                'body'    => 'request-body',
-                'headers' => [
-                    'Content-Type' => 'text/xml; charset=UTF-8',
-                ],
-            ]
+            $requestData,
+            'request-body',
+            'response-body',
+            $decodedResponse,
         );
-
-        $this->serializerMock->expects(self::once())
-            ->method('decode')
-            ->with('response-body', $txType)
-            ->willReturn(['decodedResponse']);
 
         $this->responseMapperMock->expects(self::once())
             ->method('mapRefundResponse')
-            ->with(['decodedResponse'])
+            ->with($decodedResponse)
             ->willReturn(['result']);
 
         $this->pos->refund($order);
@@ -594,39 +513,28 @@ class VakifKatilimTest extends TestCase
      */
     public function testHistoryRequest(array $order, string $apiUrl): void
     {
-        $account = $this->pos->getAccount();
-        $txType  = PosInterface::TX_TYPE_HISTORY;
+        $account     = $this->pos->getAccount();
+        $txType      = PosInterface::TX_TYPE_HISTORY;
+        $requestData = ['createHistoryRequestData'];
 
         $this->requestMapperMock->expects(self::once())
             ->method('createHistoryRequestData')
             ->with($account, $order)
-            ->willReturn(['createHistoryRequestData']);
+            ->willReturn($requestData);
 
-        $this->serializerMock->expects(self::once())
-            ->method('encode')
-            ->with(['createHistoryRequestData'], $txType)
-            ->willReturn('request-body');
-
-        $this->prepareClient(
-            $this->httpClientMock,
-            'response-body',
+        $decodedResponse = ['decodedData'];
+        $this->configureClientResponse(
+            $txType,
             $apiUrl,
-            [
-                'body'    => 'request-body',
-                'headers' => [
-                    'Content-Type' => 'text/xml; charset=UTF-8',
-                ],
-            ]
+            $requestData,
+            'request-body',
+            'response-body',
+            $decodedResponse,
         );
-
-        $this->serializerMock->expects(self::once())
-            ->method('decode')
-            ->with('response-body', $txType)
-            ->willReturn(['decodedResponse']);
 
         $this->responseMapperMock->expects(self::once())
             ->method('mapHistoryResponse')
-            ->with(['decodedResponse'])
+            ->with($decodedResponse)
             ->willReturn(['result']);
 
         $this->pos->history($order);
@@ -637,39 +545,28 @@ class VakifKatilimTest extends TestCase
      */
     public function testOrderHistoryRequest(array $order, string $apiUrl): void
     {
-        $account = $this->pos->getAccount();
-        $txType  = PosInterface::TX_TYPE_ORDER_HISTORY;
+        $account     = $this->pos->getAccount();
+        $txType      = PosInterface::TX_TYPE_ORDER_HISTORY;
+        $requestData = ['createOrderHistoryRequestData'];
 
         $this->requestMapperMock->expects(self::once())
             ->method('createOrderHistoryRequestData')
             ->with($account, $order)
-            ->willReturn(['createOrderHistoryRequestData']);
+            ->willReturn($requestData);
 
-        $this->serializerMock->expects(self::once())
-            ->method('encode')
-            ->with(['createOrderHistoryRequestData'], $txType)
-            ->willReturn('request-body');
-
-        $this->prepareClient(
-            $this->httpClientMock,
-            'response-body',
+        $decodedResponse = ['decodedData'];
+        $this->configureClientResponse(
+            $txType,
             $apiUrl,
-            [
-                'body'    => 'request-body',
-                'headers' => [
-                    'Content-Type' => 'text/xml; charset=UTF-8',
-                ],
-            ]
+            $requestData,
+            'request-body',
+            'response-body',
+            $decodedResponse,
         );
-
-        $this->serializerMock->expects(self::once())
-            ->method('decode')
-            ->with('response-body', $txType)
-            ->willReturn(['decodedResponse']);
 
         $this->responseMapperMock->expects(self::once())
             ->method('mapOrderHistoryResponse')
-            ->with(['decodedResponse'])
+            ->with($decodedResponse)
             ->willReturn(['result']);
 
         $this->pos->orderHistory($order);
@@ -877,5 +774,36 @@ class VakifKatilimTest extends TestCase
                 'api_url' => 'https://boa.vakifkatilim.com.tr/VirtualPOS.Gateway/Home/SelectOrder',
             ],
         ];
+    }
+
+    private function configureClientResponse(
+        string $txType,
+        string $apiUrl,
+        array  $requestData,
+        string $encodedRequestData,
+        string $responseContent,
+        array  $decodedResponse
+    ): void
+    {
+        $this->serializerMock->expects(self::once())
+            ->method('encode')
+            ->with($requestData, $txType)
+            ->willReturn($encodedRequestData);
+        $this->serializerMock->expects(self::once())
+            ->method('decode')
+            ->with($responseContent, $txType)
+            ->willReturn($decodedResponse);
+
+        $this->prepareClient(
+            $this->httpClientMock,
+            $responseContent,
+            $apiUrl,
+            [
+                'body'    => $encodedRequestData,
+                'headers' => [
+                    'Content-Type' => 'text/xml; charset=UTF-8',
+                ],
+            ],
+        );
     }
 }

--- a/tests/Unit/Gateways/VakifKatilimTest.php
+++ b/tests/Unit/Gateways/VakifKatilimTest.php
@@ -190,7 +190,8 @@ class VakifKatilimTest extends TestCase
             'request-body',
             'bank-api-html-response',
             $decodedResponse,
-            $order
+            $order,
+            $paymentModel
         );
 
         $this->requestMapperMock->expects(self::once())
@@ -285,7 +286,8 @@ class VakifKatilimTest extends TestCase
                 'request-body',
                 'response-body',
                 $paymentResponse,
-                $order
+                $order,
+                PosInterface::MODEL_3D_SECURE
             );
 
             $this->responseMapperMock->expects(self::once())
@@ -369,7 +371,8 @@ class VakifKatilimTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -402,7 +405,8 @@ class VakifKatilimTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -436,7 +440,8 @@ class VakifKatilimTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -469,7 +474,8 @@ class VakifKatilimTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -502,7 +508,8 @@ class VakifKatilimTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -536,7 +543,8 @@ class VakifKatilimTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -569,7 +577,8 @@ class VakifKatilimTest extends TestCase
             'request-body',
             'response-body',
             $decodedResponse,
-            $order
+            $order,
+            PosInterface::MODEL_NON_SECURE
         );
 
         $this->responseMapperMock->expects(self::once())
@@ -791,7 +800,8 @@ class VakifKatilimTest extends TestCase
         string $encodedRequestData,
         string $responseContent,
         array  $decodedResponse,
-        array  $order
+        array  $order,
+        string $paymentModel
     ): void
     {
         $this->serializerMock->expects(self::once())
@@ -817,12 +827,13 @@ class VakifKatilimTest extends TestCase
 
         $this->eventDispatcherMock->expects(self::once())
             ->method('dispatch')
-            ->with($this->callback(function ($dispatchedEvent) use ($txType, $requestData, $order) {
+            ->with($this->callback(function ($dispatchedEvent) use ($txType, $requestData, $order, $paymentModel) {
                 return $dispatchedEvent instanceof RequestDataPreparedEvent
                     && get_class($this->pos) === $dispatchedEvent->getGatewayClass()
                     && $txType === $dispatchedEvent->getTxType()
                     && $requestData === $dispatchedEvent->getRequestData()
                     && $order === $dispatchedEvent->getOrder()
+                    && $paymentModel === $dispatchedEvent->getPaymentModel()
                     ;
             }));
     }


### PR DESCRIPTION
added additional data into dispatched events to get rid of **use** statements for event listeners. Ex: 
```php
$eventDispatcher->addListener(Before3DFormHashCalculatedEvent::class, function (Before3DFormHashCalculatedEvent $event) use ($pos): void {
// ....
}
```
also PosNet -  fix 3d_all data is not available in response.