### PR TITLE
fix payflexv4pos issues

### DIFF
--- a/config/pos_production.php
+++ b/config/pos_production.php
@@ -119,7 +119,7 @@ return [
             'gateway_endpoints'  => [
                 'payment_api'     => 'https://onlineodeme.vakifbank.com.tr:4443/VposService/v3/Vposreq.aspx',
                 'gateway_3d'      => 'https://3dsecure.vakifbank.com.tr:4443/MPIAPI/MPI_Enrollment.aspx',
-                'query_api'       => 'https://sanalpos.vakifbank.com.tr/v4/UIWebService/Search.aspx',
+                'query_api'       => 'https://onlineodeme.vakifbank.com.tr:4443/UIService/Search.aspx',
             ],
         ],
         'ziraat-vpos'          => [

--- a/src/Crypt/PayFlexCPV4Crypt.php
+++ b/src/Crypt/PayFlexCPV4Crypt.php
@@ -37,7 +37,7 @@ class PayFlexCPV4Crypt extends AbstractCrypt
      */
     public function check3DHash(AbstractPosAccount $posAccount, array $data): bool
     {
-         return true;
+        throw new NotImplementedException();
     }
 
     /**

--- a/src/DataMapper/RequestDataMapper/PayFlexV4PosRequestDataMapper.php
+++ b/src/DataMapper/RequestDataMapper/PayFlexV4PosRequestDataMapper.php
@@ -341,7 +341,8 @@ class PayFlexV4PosRequestDataMapper extends AbstractRequestDataMapper
     protected function prepareStatusOrder(array $order): array
     {
         return [
-            'id' => $order['id'],
+            'id'             => $order['id'],
+            'transaction_id' => $order['transaction_id'] ?? null,
         ];
     }
 

--- a/src/DataMapper/ResponseDataMapper/GarantiPosResponseDataMapper.php
+++ b/src/DataMapper/ResponseDataMapper/GarantiPosResponseDataMapper.php
@@ -638,6 +638,7 @@ class GarantiPosResponseDataMapper extends AbstractResponseDataMapper
         if (null === $txType) {
             return null;
         }
+
         // txStatus possible values:
         // Basarili
         // Basarisiz
@@ -648,19 +649,23 @@ class GarantiPosResponseDataMapper extends AbstractResponseDataMapper
             if (PosInterface::TX_TYPE_CANCEL === $txType) {
                 return PosInterface::PAYMENT_STATUS_CANCELED;
             }
+
             if (PosInterface::TX_TYPE_REFUND === $txType) {
                 // todo how can we decide if order is partially or fully refunded?
                 return PosInterface::PAYMENT_STATUS_FULLY_REFUNDED;
             }
+
             if (PosInterface::TX_TYPE_PAY_AUTH === $txType || PosInterface::TX_TYPE_PAY_POST_AUTH === $txType) {
                 return PosInterface::PAYMENT_STATUS_PAYMENT_COMPLETED;
             }
+
             if (PosInterface::TX_TYPE_PAY_PRE_AUTH === $txType) {
                 return PosInterface::PAYMENT_STATUS_PRE_AUTH_COMPLETED;
             }
 
             return null;
         }
+
         if ('Iptal' === $txStatus) {
             return null;
         }

--- a/src/DataMapper/ResponseDataMapper/PayFlexV4PosResponseDataMapper.php
+++ b/src/DataMapper/ResponseDataMapper/PayFlexV4PosResponseDataMapper.php
@@ -91,7 +91,7 @@ class PayFlexV4PosResponseDataMapper extends AbstractResponseDataMapper
      */
     public function map3DPayResponseData(array $raw3DAuthResponseData, string $txType, array $order): array
     {
-        return $this->map3DPaymentData($raw3DAuthResponseData, $raw3DAuthResponseData, $txType, $order);
+        throw new NotImplementedException();
     }
 
     /**
@@ -99,7 +99,7 @@ class PayFlexV4PosResponseDataMapper extends AbstractResponseDataMapper
      */
     public function map3DHostResponseData(array $raw3DAuthResponseData, string $txType, array $order): array
     {
-        return $this->map3DPayResponseData($raw3DAuthResponseData, $txType, $order);
+        throw new NotImplementedException();
     }
 
     /**

--- a/src/DataMapper/ResponseDataMapper/PayFlexV4PosResponseDataMapper.php
+++ b/src/DataMapper/ResponseDataMapper/PayFlexV4PosResponseDataMapper.php
@@ -209,7 +209,11 @@ class PayFlexV4PosResponseDataMapper extends AbstractResponseDataMapper
 
         if (self::TX_APPROVED === $commonResponse['status']) {
             $commonResponse['transaction_id']   = $rawPaymentResponseData['TransactionId'];
-            $commonResponse['transaction_time'] = new \DateTimeImmutable($rawPaymentResponseData['HostDate']);
+            $txTime                             = $rawPaymentResponseData['HostDate'];
+            if (\strlen($txTime) === 10) { // ziraat is sending host date without year
+                $txTime = date('Y').$txTime;
+            }
+            $commonResponse['transaction_time'] = new \DateTimeImmutable($txTime);
             $commonResponse['auth_code']        = $rawPaymentResponseData['AuthCode'];
             $commonResponse['ref_ret_num']      = $rawPaymentResponseData['TransactionId'];
             $commonResponse['batch_num']        = $rawPaymentResponseData['BatchNo'];

--- a/src/DataMapper/ResponseDataMapper/PayFlexV4PosResponseDataMapper.php
+++ b/src/DataMapper/ResponseDataMapper/PayFlexV4PosResponseDataMapper.php
@@ -185,7 +185,7 @@ class PayFlexV4PosResponseDataMapper extends AbstractResponseDataMapper
         $defaultResponse['order_status']     = $orderStatus;
         $defaultResponse['transaction_type'] = $this->mapTxType($txResultInfo['TransactionType']);
         $defaultResponse['currency']         = $this->mapCurrency($txResultInfo['AmountCode']);
-        $defaultResponse['first_amount']     = $this->formatAmount($txResultInfo['CurrencyAmount']);
+        $defaultResponse['first_amount']     = $this->formatAmount($txResultInfo['CurrencyAmount'] ?? $txResultInfo['Amount']);
         $defaultResponse['capture_amount']   = null;
         $defaultResponse['status']           = self::PROCEDURE_SUCCESS_CODE === $orderProcCode ? self::TX_APPROVED : self::TX_DECLINED;
         $defaultResponse['error_code']       = self::PROCEDURE_SUCCESS_CODE !== $orderProcCode ? $txResultInfo['HostResultCode'] : null;

--- a/src/DataMapper/ResponseDataMapper/PayFlexV4PosResponseDataMapper.php
+++ b/src/DataMapper/ResponseDataMapper/PayFlexV4PosResponseDataMapper.php
@@ -213,6 +213,7 @@ class PayFlexV4PosResponseDataMapper extends AbstractResponseDataMapper
             if (\strlen($txTime) === 10) { // ziraat is sending host date without year
                 $txTime = date('Y').$txTime;
             }
+
             $commonResponse['transaction_time'] = new \DateTimeImmutable($txTime);
             $commonResponse['auth_code']        = $rawPaymentResponseData['AuthCode'];
             $commonResponse['ref_ret_num']      = $rawPaymentResponseData['TransactionId'];

--- a/src/Gateways/AbstractGateway.php
+++ b/src/Gateways/AbstractGateway.php
@@ -314,6 +314,7 @@ abstract class AbstractGateway implements PosInterface
         if (isset($order['order_amount']) && $order['amount'] < $order['order_amount']) {
             $txType = PosInterface::TX_TYPE_REFUND_PARTIAL;
         }
+
         $requestData = $this->requestDataMapper->createRefundRequestData($this->account, $order, $txType);
 
         $event = new RequestDataPreparedEvent(

--- a/tests/Unit/Crypt/AkbankPosCryptTest.php
+++ b/tests/Unit/Crypt/AkbankPosCryptTest.php
@@ -17,6 +17,7 @@ use Psr\Log\NullLogger;
 
 /**
  * @covers \Mews\Pos\Crypt\AkbankPosCrypt
+ * @covers \Mews\Pos\Crypt\AbstractCrypt
  */
 class AkbankPosCryptTest extends TestCase
 {

--- a/tests/Unit/Crypt/InterPosCryptTest.php
+++ b/tests/Unit/Crypt/InterPosCryptTest.php
@@ -6,7 +6,9 @@
 namespace Mews\Pos\Tests\Unit\Crypt;
 
 use Mews\Pos\Crypt\InterPosCrypt;
+use Mews\Pos\Entity\Account\AbstractPosAccount;
 use Mews\Pos\Entity\Account\InterPosAccount;
+use Mews\Pos\Exceptions\NotImplementedException;
 use Mews\Pos\Factory\AccountFactory;
 use Mews\Pos\PosInterface;
 use PHPUnit\Framework\TestCase;
@@ -14,6 +16,7 @@ use Psr\Log\NullLogger;
 
 /**
  * @covers \Mews\Pos\Crypt\InterPosCrypt
+ * @covers \Mews\Pos\Crypt\AbstractCrypt
  */
 class InterPosCryptTest extends TestCase
 {
@@ -48,6 +51,9 @@ class InterPosCryptTest extends TestCase
     public function testCheck3DHash(array $responseData): void
     {
         $this->assertTrue($this->crypt->check3DHash($this->account, $responseData));
+
+        $responseData['PurchAmount'] = '';
+        $this->assertFalse($this->crypt->check3DHash($this->account, $responseData));
     }
 
     /**
@@ -58,6 +64,22 @@ class InterPosCryptTest extends TestCase
         $actual = $this->crypt->create3DHash($this->account, $requestData);
 
         $this->assertSame($expected, $actual);
+    }
+
+    public function testCreateHash(): void
+    {
+        $this->expectException(NotImplementedException::class);
+        $this->crypt->createHash($this->account, []);
+    }
+
+    /**
+     * @dataProvider threeDHashCheckDataProvider
+     */
+    public function testCheck3DHashException(): void
+    {
+        $account = $this->createMock(AbstractPosAccount::class);
+        $this->expectException(\LogicException::class);
+        $this->crypt->check3DHash($account, []);
     }
 
     public function threeDHashCheckDataProvider(): array

--- a/tests/Unit/Crypt/PayFlexCP4CryptTest.php
+++ b/tests/Unit/Crypt/PayFlexCP4CryptTest.php
@@ -7,6 +7,7 @@ namespace Mews\Pos\Tests\Unit\Crypt;
 
 use Mews\Pos\Crypt\PayFlexCPV4Crypt;
 use Mews\Pos\Entity\Account\PayFlexAccount;
+use Mews\Pos\Exceptions\NotImplementedException;
 use Mews\Pos\Factory\AccountFactory;
 use Mews\Pos\PosInterface;
 use PHPUnit\Framework\TestCase;
@@ -14,6 +15,7 @@ use Psr\Log\NullLogger;
 
 /**
  * @covers \Mews\Pos\Crypt\PayFlexCPV4Crypt
+ * @covers \Mews\Pos\Crypt\AbstractCrypt
  */
 class PayFlexCP4CryptTest extends TestCase
 {
@@ -47,7 +49,20 @@ class PayFlexCP4CryptTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
-    public function hashCreateDataProvider(): array
+    public function testCreateHash(): void
+    {
+        $this->expectException(NotImplementedException::class);
+        $this->crypt->createHash($this->account, []);
+    }
+
+    public function testCheck3DHash(): void
+    {
+        $this->expectException(NotImplementedException::class);
+
+        $this->crypt->check3DHash($this->account, []);
+    }
+
+    public static function hashCreateDataProvider(): array
     {
         return [
             [
@@ -62,7 +77,7 @@ class PayFlexCP4CryptTest extends TestCase
         ];
     }
 
-    public function threeDHashCreateDataProvider(): array
+    public static function threeDHashCreateDataProvider(): array
     {
         return [
             [

--- a/tests/Unit/Crypt/PosNetV1PosCryptTest.php
+++ b/tests/Unit/Crypt/PosNetV1PosCryptTest.php
@@ -13,6 +13,7 @@ use Psr\Log\NullLogger;
 
 /**
  * @covers \Mews\Pos\Crypt\PosNetV1PosCrypt
+ * @covers \Mews\Pos\Crypt\AbstractCrypt
  */
 class PosNetV1PosCryptTest extends TestCase
 {
@@ -42,6 +43,17 @@ class PosNetV1PosCryptTest extends TestCase
     public function testHashFromParams(string $storeKey, array $data, string $expected): void
     {
         $this->assertSame($expected, $this->crypt->hashFromParams($storeKey, $data, 'MACParams', ':'));
+    }
+
+    public function testHashFromParamsWhenNotFound(): void
+    {
+        $data = self::hashFromParamsDataProvider()[0];
+        $this->assertSame('', $this->crypt->hashFromParams(
+            $data['storeKey'],
+            $data,
+            'NonExistingField',
+            ':'
+        ));
     }
 
     /**

--- a/tests/Unit/DataMapper/RequestDataMapper/InterPosRequestDataMapperTest.php
+++ b/tests/Unit/DataMapper/RequestDataMapper/InterPosRequestDataMapperTest.php
@@ -21,6 +21,7 @@ use Psr\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @covers \Mews\Pos\DataMapper\RequestDataMapper\InterPosRequestDataMapper
+ * @covers \Mews\Pos\DataMapper\RequestDataMapper\AbstractRequestDataMapper
  */
 class InterPosRequestDataMapperTest extends TestCase
 {
@@ -35,8 +36,6 @@ class InterPosRequestDataMapperTest extends TestCase
 
     /** @var EventDispatcherInterface & MockObject */
     private EventDispatcherInterface $dispatcher;
-
-    private array $order;
 
     protected function setUp(): void
     {
@@ -56,18 +55,7 @@ class InterPosRequestDataMapperTest extends TestCase
             $merchantPass
         );
 
-        $this->order = [
-            'id'          => 'order222',
-            'amount'      => '100.25',
-            'installment' => 0,
-            'currency'    => PosInterface::CURRENCY_TRY,
-            'success_url' => 'https://domain.com/success',
-            'fail_url'    => 'https://domain.com/fail_url',
-            'lang'        => PosInterface::LANG_TR,
-        ];
-
-        $this->dispatcher = $this->createMock(EventDispatcherInterface::class);
-
+        $this->dispatcher        = $this->createMock(EventDispatcherInterface::class);
         $this->crypt             = $this->createMock(CryptInterface::class);
         $this->requestDataMapper = new InterPosRequestDataMapper($this->dispatcher, $this->crypt);
 
@@ -125,74 +113,53 @@ class InterPosRequestDataMapperTest extends TestCase
     }
 
     /**
-     * @return void
+     * @dataProvider nonSecurePaymentPostRequestDataDataProvider
      */
-    public function testCreateNonSecurePostAuthPaymentRequestData(): void
+    public function testCreateNonSecurePostAuthPaymentRequestData(array $order, array $expectedData): void
     {
-        $order = [
-            'id'       => '2020110828BC',
-            'amount'   => 320,
-            'currency' => PosInterface::CURRENCY_TRY,
-        ];
-
         $actual = $this->requestDataMapper->createNonSecurePostAuthPaymentRequestData($this->account, $order);
 
-        $expectedData = $this->getSampleNonSecurePaymentPostRequestData($order, $this->account);
-        $this->assertEquals($expectedData, $actual);
+        $this->assertSame($expectedData, $actual);
     }
 
     /**
-     * @return void
+     * @dataProvider createNonSecurePaymentRequestDataDataProvider
      */
-    public function testCreateNonSecurePaymentRequestData(): void
+    public function testCreateNonSecurePaymentRequestData(array $order, CreditCardInterface $card, array $expected): void
     {
-        $actual = $this->requestDataMapper->createNonSecurePaymentRequestData($this->account, $this->order, PosInterface::TX_TYPE_PAY_AUTH, $this->card);
+        $actual = $this->requestDataMapper->createNonSecurePaymentRequestData(
+            $this->account,
+            $order,
+            PosInterface::TX_TYPE_PAY_AUTH,
+            $card
+        );
 
-        $expectedData = $this->getSampleNonSecurePaymentRequestData($this->order, $this->card, $this->account);
-        $this->assertEquals($expectedData, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**
-     * @return void
+     * @dataProvider createCancelRequestDataDataProvider
      */
-    public function testCreateCancelRequestData(): void
+    public function testCreateCancelRequestData(array $order, array $expected): void
     {
-        $order = [
-            'id'   => '2020110828BC',
-            'lang' => PosInterface::LANG_EN,
-        ];
-
         $actual = $this->requestDataMapper->createCancelRequestData($this->account, $order);
 
-        $expectedData = $this->getSampleCancelXMLData($order, $this->account);
-        $this->assertEquals($expectedData, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**
-     * @return void
+     * @dataProvider create3DPaymentRequestDataDataProvider
      */
-    public function testCreate3DPaymentRequestData(): void
+    public function testCreate3DPaymentRequestData(array $order, array $responseData, array $expectedData): void
     {
-        $order        = [
-            'id'          => '2020110828BC',
-            'amount'      => 100.01,
-            'installment' => 0,
-            'currency'    => PosInterface::CURRENCY_TRY,
-            'success_url' => 'http://localhost/finansbank-payfor/3d/response.php',
-            'fail_url'    => 'http://localhost/finansbank-payfor/3d/response.php',
-            'lang'        => PosInterface::LANG_EN,
-        ];
-        $responseData = [
-            'MD'                      => '1',
-            'PayerTxnId'              => '2',
-            'Eci'                     => '3',
-            'PayerAuthenticationCode' => '4',
-        ];
+        $actual = $this->requestDataMapper->create3DPaymentRequestData(
+            $this->account,
+            $order,
+            PosInterface::TX_TYPE_PAY_AUTH,
+            $responseData
+        );
 
-        $actual = $this->requestDataMapper->create3DPaymentRequestData($this->account, $order, PosInterface::TX_TYPE_PAY_AUTH, $responseData);
-
-        $expectedData = $this->getSample3DPaymentRequestData($order, $this->account, $responseData);
-        $this->assertEquals($expectedData, $actual);
+        $this->assertSame($expectedData, $actual);
     }
 
     /**
@@ -234,23 +201,17 @@ class InterPosRequestDataMapperTest extends TestCase
             $card
         );
 
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**
-     * @return void
+     * @dataProvider createStatusRequestDataDataProvider
      */
-    public function testCreateStatusRequestData(): void
+    public function testCreateStatusRequestData(array $order, array $expectedData): void
     {
-        $order = [
-            'id'   => '2020110828BC',
-            'lang' => PosInterface::LANG_EN,
-        ];
-
         $actual = $this->requestDataMapper->createStatusRequestData($this->account, $order);
 
-        $expectedData = $this->getSampleStatusRequestData($order, $this->account);
-        $this->assertEquals($expectedData, $actual);
+        $this->assertSame($expectedData, $actual);
     }
 
     /**
@@ -265,124 +226,162 @@ class InterPosRequestDataMapperTest extends TestCase
         $this->assertSame($expectedData, $actual);
     }
 
-    /**
-     * @param array           $order
-     * @param InterPosAccount $interPosAccount
-     * @param array           $responseData
-     *
-     * @return array
-     */
-    private function getSample3DPaymentRequestData(array $order, InterPosAccount $interPosAccount, array $responseData): array
+    public function testCreateOrderHistoryRequestData(): void
+    {
+        $this->expectException(\Mews\Pos\Exceptions\NotImplementedException::class);
+        $this->requestDataMapper->createOrderHistoryRequestData($this->account, []);
+    }
+
+    public function testCreateHistoryRequestData(): void
+    {
+        $this->expectException(\Mews\Pos\Exceptions\NotImplementedException::class);
+        $this->requestDataMapper->createHistoryRequestData($this->account, []);
+    }
+
+    public static function create3DPaymentRequestDataDataProvider(): array
     {
         return [
-            'UserCode'                => $interPosAccount->getUsername(),
-            'UserPass'                => $interPosAccount->getPassword(),
-            'ShopCode'                => $interPosAccount->getClientId(),
-            'TxnType'                 => 'Auth',
-            'SecureType'              => 'NonSecure',
-            'OrderId'                 => $order['id'],
-            'PurchAmount'             => $order['amount'],
-            'Currency'                => '949',
-            'InstallmentCount'        => '',
-            'MD'                      => $responseData['MD'],
-            'PayerTxnId'              => $responseData['PayerTxnId'],
-            'Eci'                     => $responseData['Eci'],
-            'PayerAuthenticationCode' => $responseData['PayerAuthenticationCode'],
-            'MOTO'                    => '0',
-            'Lang'                    => $order['lang'],
+            [
+                'order'        => [
+                    'id'     => 'order222',
+                    'amount' => '100.25',
+                    'lang'   => PosInterface::LANG_TR,
+                ],
+                'responseData' => [
+                    'MD'                      => '1',
+                    'PayerTxnId'              => '2',
+                    'Eci'                     => '3',
+                    'PayerAuthenticationCode' => '4',
+                ],
+                'expected'     => [
+                    'UserCode'                => 'InterTestApi',
+                    'UserPass'                => '3',
+                    'ShopCode'                => '3123',
+                    'TxnType'                 => 'Auth',
+                    'SecureType'              => 'NonSecure',
+                    'OrderId'                 => 'order222',
+                    'PurchAmount'             => '100.25',
+                    'Currency'                => '949',
+                    'InstallmentCount'        => '',
+                    'MD'                      => '1',
+                    'PayerTxnId'              => '2',
+                    'Eci'                     => '3',
+                    'PayerAuthenticationCode' => '4',
+                    'MOTO'                    => '0',
+                    'Lang'                    => PosInterface::LANG_TR,
+                ],
+            ],
         ];
     }
 
-    /**
-     * @param array           $order
-     * @param InterPosAccount $interPosAccount
-     *
-     * @return array
-     */
-    private function getSampleCancelXMLData(array $order, InterPosAccount $interPosAccount): array
+    public static function createCancelRequestDataDataProvider(): array
     {
         return [
-            'UserCode'   => $interPosAccount->getUsername(),
-            'UserPass'   => $interPosAccount->getPassword(),
-            'ShopCode'   => $interPosAccount->getClientId(),
-            'OrderId'    => null,
-            'orgOrderId' => $order['id'],
-            'TxnType'    => 'Void',
-            'SecureType' => 'NonSecure',
-            'Lang'       => $order['lang'],
+            [
+                'order'    => [
+                    'id'   => '2020110828BC',
+                    'lang' => PosInterface::LANG_EN,
+                ],
+                'expected' => [
+                    'UserCode'   => 'InterTestApi',
+                    'UserPass'   => '3',
+                    'ShopCode'   => '3123',
+                    'OrderId'    => null,
+                    'orgOrderId' => '2020110828BC',
+                    'TxnType'    => 'Void',
+                    'SecureType' => 'NonSecure',
+                    'Lang'       => PosInterface::LANG_EN,
+                ],
+            ],
         ];
     }
 
-    /**
-     * @param array               $order
-     * @param CreditCardInterface $creditCard
-     * @param InterPosAccount     $interPosAccount
-     *
-     * @return array
-     */
-    private function getSampleNonSecurePaymentRequestData(array $order, CreditCardInterface $creditCard, InterPosAccount $interPosAccount): array
+
+    public static function createNonSecurePaymentRequestDataDataProvider(): array
     {
-        $requestData = [
-            'UserCode'         => $interPosAccount->getUsername(),
-            'UserPass'         => $interPosAccount->getPassword(),
-            'ShopCode'         => $interPosAccount->getClientId(),
-            'TxnType'          => 'Auth',
-            'SecureType'       => 'NonSecure',
-            'OrderId'          => $order['id'],
-            'PurchAmount'      => $order['amount'],
-            'Currency'         => '949',
-            'InstallmentCount' => '',
-            'MOTO'             => '0',
-            'Lang'             => $order['lang'],
-        ];
+        $card = CreditCardFactory::create(
+            '5555444433332222',
+            '21',
+            '12',
+            '122',
+            'ahmet',
+            CreditCardInterface::CARD_TYPE_VISA
+        );
 
-        $requestData['CardType'] = '0';
-        $requestData['Pan']      = $creditCard->getNumber();
-        $requestData['Expiry']   = '1221';
-        $requestData['Cvv2']     = $creditCard->getCvv();
-
-        return $requestData;
-    }
-
-    /**
-     * @param array           $order
-     * @param InterPosAccount $interPosAccount
-     *
-     * @return array
-     */
-    private function getSampleNonSecurePaymentPostRequestData(array $order, InterPosAccount $interPosAccount): array
-    {
         return [
-            'UserCode'    => $interPosAccount->getUsername(),
-            'UserPass'    => $interPosAccount->getPassword(),
-            'ShopCode'    => $interPosAccount->getClientId(),
-            'TxnType'     => 'PostAuth',
-            'SecureType'  => 'NonSecure',
-            'OrderId'     => null,
-            'orgOrderId'  => $order['id'],
-            'PurchAmount' => $order['amount'],
-            'Currency'    => '949',
-            'MOTO'        => '0',
+            [
+                'order'    => [
+                    'id'          => 'order222',
+                    'amount'      => '100.25',
+                    'installment' => 0,
+                    'currency'    => PosInterface::CURRENCY_TRY,
+                    'lang'        => PosInterface::LANG_TR,
+                ],
+                'card'     => $card,
+                'expected' => [
+                    'UserCode'         => 'InterTestApi',
+                    'UserPass'         => '3',
+                    'ShopCode'         => '3123',
+                    'TxnType'          => 'Auth',
+                    'SecureType'       => 'NonSecure',
+                    'OrderId'          => 'order222',
+                    'PurchAmount'      => '100.25',
+                    'Currency'         => '949',
+                    'InstallmentCount' => '',
+                    'MOTO'             => '0',
+                    'Lang'             => PosInterface::LANG_TR,
+                    'CardType'         => '0',
+                    'Pan'              => $card->getNumber(),
+                    'Expiry'           => '1221',
+                    'Cvv2'             => $card->getCvv(),
+                ],
+            ],
         ];
     }
 
-    /**
-     * @param array           $order
-     * @param InterPosAccount $interPosAccount
-     *
-     * @return array
-     */
-    private function getSampleStatusRequestData(array $order, InterPosAccount $interPosAccount): array
+    public static function nonSecurePaymentPostRequestDataDataProvider(): array
     {
         return [
-            'UserCode'   => $interPosAccount->getUsername(),
-            'UserPass'   => $interPosAccount->getPassword(),
-            'ShopCode'   => $interPosAccount->getClientId(),
-            'OrderId'    => null,
-            'orgOrderId' => $order['id'],
-            'TxnType'    => 'StatusHistory',
-            'SecureType' => 'NonSecure',
-            'Lang'       => $order['lang'],
+            [
+                'order'    => [
+                    'id'     => 'order222',
+                    'amount' => 10.0,
+                ],
+                'expected' => [
+                    'UserCode'    => 'InterTestApi',
+                    'UserPass'    => '3',
+                    'ShopCode'    => '3123',
+                    'TxnType'     => 'PostAuth',
+                    'SecureType'  => 'NonSecure',
+                    'OrderId'     => null,
+                    'orgOrderId'  => 'order222',
+                    'PurchAmount' => '10',
+                    'Currency'    => '949',
+                    'MOTO'        => '0',
+                ],
+            ],
+        ];
+    }
+
+    public static function createStatusRequestDataDataProvider(): array
+    {
+        return [
+            [
+                'order'    => [
+                    'id'   => 'order222',
+                    'lang' => PosInterface::LANG_TR,
+                ],
+                'expected' => [
+                    'UserCode'   => 'InterTestApi',
+                    'UserPass'   => '3',
+                    'ShopCode'   => '3123',
+                    'OrderId'    => null,
+                    'orgOrderId' => 'order222',
+                    'TxnType'    => 'StatusHistory',
+                    'SecureType' => 'NonSecure',
+                    'Lang'       => PosInterface::LANG_TR,
+                ],
+            ],
         ];
     }
 
@@ -446,11 +445,11 @@ class InterPosRequestDataMapperTest extends TestCase
                         'Lang'             => 'tr',
                         'Currency'         => '949',
                         'InstallmentCount' => '',
-                        'Hash'             => 'vEbwP8wnsGrBR9oCjfxP9wlho1g=',
                         'CardType'         => '0',
                         'Pan'              => '5555444433332222',
                         'Expiry'           => '1221',
                         'Cvv2'             => '122',
+                        'Hash'             => 'vEbwP8wnsGrBR9oCjfxP9wlho1g=',
                     ],
                 ],
             ],

--- a/tests/Unit/DataMapper/RequestDataMapper/InterPosRequestDataMapperTest.php
+++ b/tests/Unit/DataMapper/RequestDataMapper/InterPosRequestDataMapperTest.php
@@ -125,13 +125,13 @@ class InterPosRequestDataMapperTest extends TestCase
     /**
      * @dataProvider createNonSecurePaymentRequestDataDataProvider
      */
-    public function testCreateNonSecurePaymentRequestData(array $order, CreditCardInterface $card, array $expected): void
+    public function testCreateNonSecurePaymentRequestData(array $order, CreditCardInterface $creditCard, array $expected): void
     {
         $actual = $this->requestDataMapper->createNonSecurePaymentRequestData(
             $this->account,
             $order,
             PosInterface::TX_TYPE_PAY_AUTH,
-            $card
+            $creditCard
         );
 
         $this->assertSame($expected, $actual);

--- a/tests/Unit/DataMapper/RequestDataMapper/PayFlexV4PosRequestDataMapperTest.php
+++ b/tests/Unit/DataMapper/RequestDataMapper/PayFlexV4PosRequestDataMapperTest.php
@@ -248,6 +248,18 @@ class PayFlexV4PosRequestDataMapperTest extends TestCase
         $this->assertEquals($expectedValue, $actualData);
     }
 
+    public function testCreateOrderHistoryRequestData(): void
+    {
+        $this->expectException(\Mews\Pos\Exceptions\NotImplementedException::class);
+        $this->requestDataMapper->createOrderHistoryRequestData($this->account, []);
+    }
+
+    public function testCreateHistoryRequestData(): void
+    {
+        $this->expectException(\Mews\Pos\Exceptions\NotImplementedException::class);
+        $this->requestDataMapper->createHistoryRequestData($this->account, []);
+    }
+
     /**
      * @return array
      */

--- a/tests/Unit/DataMapper/RequestDataMapper/PayFlexV4PosRequestDataMapperTest.php
+++ b/tests/Unit/DataMapper/RequestDataMapper/PayFlexV4PosRequestDataMapperTest.php
@@ -248,6 +248,16 @@ class PayFlexV4PosRequestDataMapperTest extends TestCase
         $this->assertEquals($expectedValue, $actualData);
     }
 
+    /**
+     * @dataProvider createStatusRequestDataDataProvider
+     */
+    public function testCreateStatusRequestData(array $order, array $expectedData): void
+    {
+        $actual = $this->requestDataMapper->createStatusRequestData($this->account, $order);
+
+        $this->assertSame($expectedData, $actual);
+    }
+
     public function testCreateOrderHistoryRequestData(): void
     {
         $this->expectException(\Mews\Pos\Exceptions\NotImplementedException::class);
@@ -258,6 +268,45 @@ class PayFlexV4PosRequestDataMapperTest extends TestCase
     {
         $this->expectException(\Mews\Pos\Exceptions\NotImplementedException::class);
         $this->requestDataMapper->createHistoryRequestData($this->account, []);
+    }
+
+    public static function createStatusRequestDataDataProvider(): array
+    {
+        return [
+            'only_with_order_id'      => [
+                'order'    => [
+                    'id' => 'order222',
+                ],
+                'expected' => [
+                    'MerchantCriteria'    => [
+                        'HostMerchantId'   => '000000000111111',
+                        'MerchantPassword' => '3XTgER89as',
+                    ],
+                    'TransactionCriteria' => [
+                        'TransactionId' => '',
+                        'OrderId'       => 'order222',
+                        'AuthCode'      => '',
+                    ],
+                ],
+            ],
+            'with_order_id_and_tx_id' => [
+                'order'    => [
+                    'id'             => 'order222',
+                    'transaction_id' => 'tx222',
+                ],
+                'expected' => [
+                    'MerchantCriteria'    => [
+                        'HostMerchantId'   => '000000000111111',
+                        'MerchantPassword' => '3XTgER89as',
+                    ],
+                    'TransactionCriteria' => [
+                        'TransactionId' => 'tx222',
+                        'OrderId'       => 'order222',
+                        'AuthCode'      => '',
+                    ],
+                ],
+            ],
+        ];
     }
 
     /**

--- a/tests/Unit/DataMapper/ResponseDataMapper/GarantiPosResponseDataMapperTest.php
+++ b/tests/Unit/DataMapper/ResponseDataMapper/GarantiPosResponseDataMapperTest.php
@@ -17,6 +17,7 @@ use Psr\Log\NullLogger;
 
 /**
  * @covers \Mews\Pos\DataMapper\ResponseDataMapper\GarantiPosResponseDataMapper
+ * @covers \Mews\Pos\DataMapper\ResponseDataMapper\AbstractResponseDataMapper
  */
 class GarantiPosResponseDataMapperTest extends TestCase
 {
@@ -1789,6 +1790,7 @@ class GarantiPosResponseDataMapperTest extends TestCase
                     new \DateTimeZone($item['transaction_time']['timezone'])
                 );
             }
+
             if (null !== $item['capture_time']) {
                 $item['capture_time'] = new \DateTimeImmutable(
                     $item['capture_time']['date'],

--- a/tests/Unit/DataMapper/ResponseDataMapper/InterPosResponseDataMapperTest.php
+++ b/tests/Unit/DataMapper/ResponseDataMapper/InterPosResponseDataMapperTest.php
@@ -96,6 +96,7 @@ class InterPosResponseDataMapperTest extends TestCase
         } else {
             $this->assertEquals($expectedData['transaction_time'], $actualData['transaction_time']);
         }
+
         unset($actualData['transaction_time'], $expectedData['transaction_time']);
 
         $this->assertArrayHasKey('3d_all', $actualData);

--- a/tests/Unit/DataMapper/ResponseDataMapper/InterPosResponseDataMapperTest.php
+++ b/tests/Unit/DataMapper/ResponseDataMapper/InterPosResponseDataMapperTest.php
@@ -73,6 +73,7 @@ class InterPosResponseDataMapperTest extends TestCase
         $actualData = $this->responseDataMapper->mapPaymentResponse($responseData, $txType, $order);
         $this->assertEquals($expectedData['transaction_time'], $actualData['transaction_time']);
         unset($actualData['transaction_time'], $expectedData['transaction_time']);
+        $this->assertArrayHasKey('all', $actualData);
         unset($actualData['all']);
         \ksort($expectedData);
         \ksort($actualData);
@@ -210,64 +211,89 @@ class InterPosResponseDataMapperTest extends TestCase
     }
 
 
-    public function paymentTestDataProvider(): array
+    public static function paymentTestDataProvider(): array
     {
-        return
-            [
-                'fail1' => [
-                    'order'        => [
-                        'currency' => PosInterface::CURRENCY_TRY,
-                        'amount'   => 1.01,
-                    ],
-                    'txType'       => PosInterface::TX_TYPE_PAY_AUTH,
-                    'responseData' => [
-                        'OrderId'               => '20221225662C',
-                        'ProcReturnCode'        => '81',
-                        'HostRefNum'            => 'hostid',
-                        'AuthCode'              => '',
-                        'TxnResult'             => 'Failed',
-                        'ErrorMessage'          => 'Terminal Aktif Degil',
-                        'CampanyId'             => '',
-                        'CampanyInstallCount'   => '0',
-                        'CampanyShiftDateCount' => '0',
-                        'CampanyTxnId'          => '',
-                        'CampanyType'           => '',
-                        'CampanyInstallment'    => '0',
-                        'CampanyDate'           => '0',
-                        'CampanyAmnt'           => '0',
-                        'TRXDATE'               => '',
-                        'TransId'               => '',
-                        'ErrorCode'             => 'B810002',
-                        'EarnedBonus'           => '0',
-                        'UsedBonus'             => '0',
-                        'AvailableBonus'        => '0',
-                        'BonusToBonus'          => '0',
-                        'CampaignBonus'         => '0',
-                        'FoldedBonus'           => '0',
-                        'SurchargeAmount'       => '0',
-                        'Amount'                => '1,01',
-                        'CardHolderName'        => '',
-                    ],
-                    'expectedData' => [
-                        'order_id'          => '20221225662C',
-                        'transaction_id'    => null,
-                        'transaction_type'  => 'pay',
-                        'currency'          => 'TRY',
-                        'amount'            => 1.01,
-                        'payment_model'     => 'regular',
-                        'auth_code'         => null,
-                        'ref_ret_num'       => 'hostid',
-                        'batch_num'         => null,
-                        'proc_return_code'  => '81',
-                        'status'            => 'declined',
-                        'status_detail'     => 'invalid_credentials',
-                        'error_code'        => 'B810002',
-                        'error_message'     => 'Terminal Aktif Degil',
-                        'installment_count' => null,
-                        'transaction_time'  => null,
-                    ],
+        return [
+            'fail1' => [
+                'order'        => [
+                    'currency' => PosInterface::CURRENCY_TRY,
+                    'amount'   => 1.01,
                 ],
-            ];
+                'txType'       => PosInterface::TX_TYPE_PAY_AUTH,
+                'responseData' => [
+                    'OrderId'               => '20221225662C',
+                    'ProcReturnCode'        => '81',
+                    'HostRefNum'            => 'hostid',
+                    'AuthCode'              => '',
+                    'TxnResult'             => 'Failed',
+                    'ErrorMessage'          => 'Terminal Aktif Degil',
+                    'CampanyId'             => '',
+                    'CampanyInstallCount'   => '0',
+                    'CampanyShiftDateCount' => '0',
+                    'CampanyTxnId'          => '',
+                    'CampanyType'           => '',
+                    'CampanyInstallment'    => '0',
+                    'CampanyDate'           => '0',
+                    'CampanyAmnt'           => '0',
+                    'TRXDATE'               => '',
+                    'TransId'               => '',
+                    'ErrorCode'             => 'B810002',
+                    'EarnedBonus'           => '0',
+                    'UsedBonus'             => '0',
+                    'AvailableBonus'        => '0',
+                    'BonusToBonus'          => '0',
+                    'CampaignBonus'         => '0',
+                    'FoldedBonus'           => '0',
+                    'SurchargeAmount'       => '0',
+                    'Amount'                => '1,01',
+                    'CardHolderName'        => '',
+                ],
+                'expectedData' => [
+                    'order_id'          => '20221225662C',
+                    'transaction_id'    => null,
+                    'transaction_type'  => 'pay',
+                    'currency'          => 'TRY',
+                    'amount'            => 1.01,
+                    'payment_model'     => 'regular',
+                    'auth_code'         => null,
+                    'ref_ret_num'       => 'hostid',
+                    'batch_num'         => null,
+                    'proc_return_code'  => '81',
+                    'status'            => 'declined',
+                    'status_detail'     => 'invalid_credentials',
+                    'error_code'        => 'B810002',
+                    'error_message'     => 'Terminal Aktif Degil',
+                    'installment_count' => null,
+                    'transaction_time'  => null,
+                ],
+            ],
+            'empty' => [
+                'order'        => [
+                    'currency' => PosInterface::CURRENCY_TRY,
+                    'amount'   => 1.01,
+                ],
+                'txType'       => PosInterface::TX_TYPE_PAY_AUTH,
+                'responseData' => [],
+                'expectedData' => [
+                    'order_id'          => null,
+                    'transaction_id'    => null,
+                    'transaction_time'  => null,
+                    'transaction_type'  => PosInterface::TX_TYPE_PAY_AUTH,
+                    'installment_count' => null,
+                    'currency'          => null,
+                    'amount'            => null,
+                    'payment_model'     => 'regular',
+                    'auth_code'         => null,
+                    'ref_ret_num'       => null,
+                    'batch_num'         => null,
+                    'proc_return_code'  => null,
+                    'status'            => 'declined',
+                    'status_detail'     => null,
+                    'error_code'        => null,
+                    'error_message'     => null,
+                ],
+            ],
+        ];
     }
 
 

--- a/tests/Unit/DataMapper/ResponseDataMapper/PayFlexV4PosResponseDataMapperTest.php
+++ b/tests/Unit/DataMapper/ResponseDataMapper/PayFlexV4PosResponseDataMapperTest.php
@@ -401,6 +401,57 @@ class PayFlexV4PosResponseDataMapperTest extends TestCase
             ],
         ];
 
+        yield 'success_with_short_host_date' => [
+            'txType'       => PosInterface::TX_TYPE_PAY_PRE_AUTH,
+            'responseData' => [
+                'MerchantId'              => '000100000013506',
+                'TransactionType'         => 'Sale',
+                'TransactionId'           => '9972767117b3400eb2acafc0018643df',
+                'ResultCode'              => '0000',
+                'ResultDetail'            => 'İŞLEM BAŞARILI',
+                'CustomItems'             => [
+                    'Item' => [
+                        '@name'  => 'CardHolderName',
+                        '@value' => 'AR* ÖZ*',
+                        '#'      => null,
+                    ],
+                ],
+                'InstallmentTable'        => null,
+                'CampaignResult'          => null,
+                'AuthCode'                => '961451',
+                'HostDate'                => '0309234054',
+                'Rrn'                     => '306823971358',
+                'TerminalNo'              => 'VP000579',
+                'GainedPoint'             => '10.00',
+                'TotalPoint'              => '103032.52',
+                'CurrencyAmount'          => '1.01',
+                'CurrencyCode'            => '949',
+                'OrderId'                 => '202303095646',
+                'ThreeDSecureType'        => '1',
+                'TransactionDeviceSource' => '0',
+                'BatchNo'                 => '300',
+                'TLAmount'                => '1.01',
+            ],
+            'expectedData' => [
+                'transaction_id'    => '9972767117b3400eb2acafc0018643df',
+                'transaction_type'  => 'pay',
+                'transaction_time'  => new \DateTimeImmutable('2024-03-09 23:40:54'),
+                'auth_code'         => '961451',
+                'ref_ret_num'       => '9972767117b3400eb2acafc0018643df',
+                'batch_num'         => '300',
+                'order_id'          => '202303095646',
+                'proc_return_code'  => '0000',
+                'status'            => 'approved',
+                'status_detail'     => 'approved',
+                'error_code'        => null,
+                'error_message'     => null,
+                'currency'          => 'TRY',
+                'amount'            => 1.01,
+                'payment_model'     => 'regular',
+                'installment_count' => null,
+            ],
+        ];
+
         yield 'fail_1' => [
             'txType'       => PosInterface::TX_TYPE_PAY_PRE_AUTH,
             'responseData' => [

--- a/tests/Unit/DataMapper/ResponseDataMapper/PayFlexV4PosResponseDataMapperTest.php
+++ b/tests/Unit/DataMapper/ResponseDataMapper/PayFlexV4PosResponseDataMapperTest.php
@@ -8,6 +8,7 @@ namespace Mews\Pos\Tests\Unit\DataMapper\ResponseDataMapper;
 use Mews\Pos\Crypt\CryptInterface;
 use Mews\Pos\DataMapper\RequestDataMapper\PayFlexV4PosRequestDataMapper;
 use Mews\Pos\DataMapper\ResponseDataMapper\PayFlexV4PosResponseDataMapper;
+use Mews\Pos\Exceptions\NotImplementedException;
 use Mews\Pos\PosInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\EventDispatcher\EventDispatcherInterface;
@@ -15,6 +16,7 @@ use Psr\Log\NullLogger;
 
 /**
  * @covers \Mews\Pos\DataMapper\ResponseDataMapper\PayFlexV4PosResponseDataMapper
+ * @covers \Mews\Pos\DataMapper\ResponseDataMapper\AbstractResponseDataMapper
  */
 class PayFlexV4PosResponseDataMapperTest extends TestCase
 {
@@ -129,6 +131,30 @@ class PayFlexV4PosResponseDataMapperTest extends TestCase
         \ksort($expectedData);
         \ksort($actualData);
         $this->assertSame($expectedData, $actualData);
+    }
+
+    public function testMap3DPayResponseData(): void
+    {
+        $this->expectException(NotImplementedException::class);
+        $this->responseDataMapper->map3DPayResponseData([], PosInterface::TX_TYPE_PAY_AUTH, []);
+    }
+
+    public function testMap3DHostResponseData(): void
+    {
+        $this->expectException(NotImplementedException::class);
+        $this->responseDataMapper->map3DHostResponseData([], PosInterface::TX_TYPE_PAY_AUTH, []);
+    }
+
+    public function testMapHistoryResponse(): void
+    {
+        $this->expectException(NotImplementedException::class);
+        $this->responseDataMapper->mapHistoryResponse([]);
+    }
+
+    public function testMapOrderHistoryResponse(): void
+    {
+        $this->expectException(NotImplementedException::class);
+        $this->responseDataMapper->mapOrderHistoryResponse([]);
     }
 
     public static function statusTestDataProvider(): iterable

--- a/tests/Unit/DataMapper/ResponseDataMapper/PayFlexV4PosResponseDataMapperTest.php
+++ b/tests/Unit/DataMapper/ResponseDataMapper/PayFlexV4PosResponseDataMapperTest.php
@@ -435,7 +435,7 @@ class PayFlexV4PosResponseDataMapperTest extends TestCase
             'expectedData' => [
                 'transaction_id'    => '9972767117b3400eb2acafc0018643df',
                 'transaction_type'  => 'pay',
-                'transaction_time'  => new \DateTimeImmutable('2024-03-09 23:40:54'),
+                'transaction_time'  => new \DateTimeImmutable(date('Y').'-03-09 23:40:54'),
                 'auth_code'         => '961451',
                 'ref_ret_num'       => '9972767117b3400eb2acafc0018643df',
                 'batch_num'         => '300',

--- a/tests/Unit/DataMapper/ResponseDataMapper/VakifKatilimPosResponseDataMapperTest.php
+++ b/tests/Unit/DataMapper/ResponseDataMapper/VakifKatilimPosResponseDataMapperTest.php
@@ -17,6 +17,7 @@ use Psr\Log\NullLogger;
 
 /**
  * @covers \Mews\Pos\DataMapper\ResponseDataMapper\VakifKatilimPosResponseDataMapper
+ * @covers \Mews\Pos\DataMapper\ResponseDataMapper\AbstractResponseDataMapper
  */
 class VakifKatilimPosResponseDataMapperTest extends TestCase
 {
@@ -220,16 +221,22 @@ class VakifKatilimPosResponseDataMapperTest extends TestCase
         $actualData = $this->responseDataMapper->mapHistoryResponse(json_decode($responseData, true));
 
         $this->assertCount(31, $actualData['transactions']);
-
-        if (count($actualData['transactions']) > 1
-            && null !== $actualData['transactions'][0]['transaction_time']
-            && null !== $actualData['transactions'][1]['transaction_time']
-        ) {
-            $this->assertGreaterThan(
-                $actualData['transactions'][0]['transaction_time'],
-                $actualData['transactions'][1]['transaction_time'],
-            );
+        if (count($actualData['transactions']) <= 1) {
+            return;
         }
+
+        if (null === $actualData['transactions'][0]['transaction_time']) {
+            return;
+        }
+
+        if (null === $actualData['transactions'][1]['transaction_time']) {
+            return;
+        }
+
+        $this->assertGreaterThan(
+            $actualData['transactions'][0]['transaction_time'],
+            $actualData['transactions'][1]['transaction_time'],
+        );
     }
 
 


### PR DESCRIPTION
- throw exception for unimplemented payments models 3d pay and 3d host 
- throw exception for and unimplemented PayFlexCPV4Crypt method check3DHash
- fix order status is not considering transaction_id
- fix issue #230 
- fix issue #229