### PR TITLE
Issue 274 ziraat katilim payfor support

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,12 +238,6 @@ gerekiyor. [çözüm](https://stackoverflow.com/a/51128675/4896948).
   gerekmekte.
   Bu hatayı alırsanız hosting firmanın verdiği IP adrese'de banka gateway'i
   tarafından izin verilmesini sağlayın.
-- kütüphane ortam değerini de kontrol etmeyi unutmayınız.
-    - test ortamı için `$pos->setTestMode(true);`
-    - canlı ortam için `$pos->setTestMode(false);` (default olarak `false`)
-
-  _ortam değeri hem bankaya istek gönderirken hem de gelen isteği işlerken doğru
-  deger olması gerekiyor._
 
 ### Debugging
 

--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,7 @@
         "rector/rector": "^2.0",
         "slim/psr7": "^1.4",
         "squizlabs/php_codesniffer": "^3.5",
+        "symfony/dotenv": "^5.4",
         "symfony/event-dispatcher": "^5.4",
         "symfony/http-client": "^5.4",
         "symfony/var-dumper": "^5.1",

--- a/config/pos_production.php
+++ b/config/pos_production.php
@@ -117,6 +117,10 @@ return [
         'ziraat-katilim-payfor' => [
             'name'              => 'ZiraatKatilim-PayFor',
             'class'             => Mews\Pos\Gateways\PayForPos::class,
+            'gateway_configs'   => [
+                // Ziraat Katilim için hash kontrolü çalışmıyor. O yüzden devre dışı bırakıyoruz.
+                'disable_3d_hash_check' => true,
+            ],
             'gateway_endpoints' => [
                 'payment_api'     => 'https://vpos.ziraatkatilim.com.tr/Mpi/XMLGate.aspx',
                 'gateway_3d'      => 'https://vpos.ziraatkatilim.com.tr/Mpi/Default.aspx',

--- a/config/pos_production.php
+++ b/config/pos_production.php
@@ -114,6 +114,15 @@ return [
                 'gateway_3d_host' => 'https://vpos.qnbfinansbank.com/Gateway/3DHost.aspx',
             ],
         ],
+        'ziraat-katilim-payfor' => [
+            'name'              => 'ZiraatKatilim-PayFor',
+            'class'             => Mews\Pos\Gateways\PayForPos::class,
+            'gateway_endpoints' => [
+                'payment_api'     => 'https://vpos.ziraatkatilim.com.tr/Mpi/XMLGate.aspx',
+                'gateway_3d'      => 'https://vpos.ziraatkatilim.com.tr/Mpi/Default.aspx',
+                'gateway_3d_host' => 'https://vpos.ziraatkatilim.com.tr/Mpi/3Dhost.aspx',
+            ],
+        ],
         'vakifbank'            => [
             'name'  => 'VakifBank-VPOS',
             'class' => Mews\Pos\Gateways\PayFlexV4Pos::class,

--- a/config/pos_test.php
+++ b/config/pos_test.php
@@ -79,6 +79,15 @@ return [
                 'gateway_3d_host' => 'https://vpostest.qnbfinansbank.com/Gateway/3DHost.aspx',
             ],
         ],
+        'ziraat-katilim-payfor' => [
+            'name'              => 'ZiraatKatilim-PayFor',
+            'class'             => Mews\Pos\Gateways\PayForPos::class,
+            'gateway_endpoints' => [
+                'payment_api'     => 'https://payfortestziraatkatilim.cordisnetwork.com/Mpi/XMLGate.aspx',
+                'gateway_3d'      => 'https://payfortestziraatkatilim.cordisnetwork.com/Mpi/Default.aspx',
+                'gateway_3d_host' => 'https://payfortestziraatkatilim.cordisnetwork.com/Mpi/3DHost.aspx',
+            ],
+        ],
         'vakifbank'            => [
             'name'              => 'VakifBank-VPOS',
             'class'             => Mews\Pos\Gateways\PayFlexV4Pos::class,

--- a/config/pos_test.php
+++ b/config/pos_test.php
@@ -65,6 +65,10 @@ return [
         'garanti'              => [
             'name'              => 'Garanti',
             'class'             => Mews\Pos\Gateways\GarantiPos::class,
+            'gateway_configs' => [
+                // GarantiPos'u test ortamda test edebilmek için zorunlu.
+                'test_mode' => true,
+            ],
             'gateway_endpoints' => [
                 'payment_api' => 'https://sanalposprovtest.garantibbva.com.tr/VPServlet',
                 'gateway_3d'  => 'https://sanalposprovtest.garantibbva.com.tr/servlet/gt3dengine',
@@ -82,6 +86,10 @@ return [
         'ziraat-katilim-payfor' => [
             'name'              => 'ZiraatKatilim-PayFor',
             'class'             => Mews\Pos\Gateways\PayForPos::class,
+            'gateway_configs'   => [
+                // Ziraat Katilim için hash kontrolü çalışmıyor. O yüzden devre dışı bırakıyoruz.
+                'disable_3d_hash_check' => true,
+            ],
             'gateway_endpoints' => [
                 'payment_api'     => 'https://payfortestziraatkatilim.cordisnetwork.com/Mpi/XMLGate.aspx',
                 'gateway_3d'      => 'https://payfortestziraatkatilim.cordisnetwork.com/Mpi/Default.aspx',
@@ -126,6 +134,10 @@ return [
         'kuveytpos'            => [
             'name'              => 'kuveyt-pos',
             'class'             => Mews\Pos\Gateways\KuveytPos::class,
+            'gateway_configs' => [
+                // testinizi SSL olmayan ortamda yapıyorsanız bu değeri true yapmanız gerekir.
+                'test_mode' => true,
+            ],
             'gateway_endpoints' => [
                 'payment_api' => 'https://boatest.kuveytturk.com.tr/boa.virtualpos.services/Home',
                 'gateway_3d'  => 'https://boatest.kuveytturk.com.tr/boa.virtualpos.services/Home/ThreeDModelPayGate',

--- a/docs/CANCEL-EXAMPLE.md
+++ b/docs/CANCEL-EXAMPLE.md
@@ -30,9 +30,6 @@ try {
     $config = require __DIR__.'/pos_test_ayarlar.php';
 
     $pos = \Mews\Pos\Factory\PosFactory::createPosGateway($account, $config, $eventDispatcher);
-
-    // GarantiPos'u test ortamda test edebilmek için zorunlu.
-    $pos->setTestMode(true);
 } catch (\Mews\Pos\Exceptions\BankNotFoundException | \Mews\Pos\Exceptions\BankClassNullException $e) {
     var_dump($e));
     exit;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,12 +1,33 @@
 # Changelog
-## [1.7.0] - 2025-09-25
+## [1.7.0] - 2025-10-04
 
 ### New Features
 - **PayForPos** - `MbrId` (Kurum kodu) Account oluştururken tanımlanabilinir.
   (issue #274 Ziraat Katılım bankası desteği).
-
+- Kütüphane config dosyasına yeni `test_mode` ve `disable_3d_hash_check` ayarlar desteği eklendi.
+  Örnek:
+    ```php
+    [
+        'banks' => [
+          'garanti' => [
+            'name'              => 'Garanti',
+            'class'             => Mews\Pos\Gateways\GarantiPos::class,
+            'gateway_configs' => [
+                'test_mode'             => true, // default: false
+                // 3D hash kontrolü çalışmadığında geçici olarak kullanılabilir.
+                'disable_3d_hash_check' => true, // default: false
+             ],
+             'gateway_endpoints' => [
+                'payment_api' => 'https://sanalposprovtest.garantibbva.com.tr/VPServlet',
+                'gateway_3d'  => 'https://sanalposprovtest.garantibbva.com.tr/servlet/gt3dengine',
+             ],
+          ],
+        ]
+    ]
+    ```
 ### Changed
 - **PayFlexV4Pos** - tekrarlanan ödeme için `startDate` parametresi eklendi.
+- **PosInterface::setTestMode()** deprecated. Yerine config dosyasına `test_mode` ekleyebilirsiniz.
 
 ### Fixed
 - **PayFlexV4Pos** - provizyon kapatma işlemi çalışmıyor.

--- a/docs/CUSTOM-QUERY-EXAMPLE.md
+++ b/docs/CUSTOM-QUERY-EXAMPLE.md
@@ -28,9 +28,6 @@ try {
     $config = require __DIR__.'/pos_test_ayarlar.php';
 
     $pos = \Mews\Pos\Factory\PosFactory::createPosGateway($account, $config, $eventDispatcher);
-
-    // GarantiPos'u test ortamda test edebilmek için zorunlu.
-    $pos->setTestMode(true);
 } catch (\Mews\Pos\Exceptions\BankNotFoundException | \Mews\Pos\Exceptions\BankClassNullException $e) {
     var_dump($e));
     exit;

--- a/docs/HISTORY-EXAMPLE.md
+++ b/docs/HISTORY-EXAMPLE.md
@@ -30,9 +30,6 @@ try {
     $config = require __DIR__.'/pos_test_ayarlar.php';
 
     $pos = \Mews\Pos\Factory\PosFactory::createPosGateway($account, $config, $eventDispatcher);
-
-    // GarantiPos'u test ortamda test edebilmek için zorunlu.
-    $pos->setTestMode(true);
 } catch (\Mews\Pos\Exceptions\BankNotFoundException | \Mews\Pos\Exceptions\BankClassNullException $e) {
     var_dump($e));
     exit;

--- a/docs/NON-SECURE-PAYMENT-EXAMPLE.md
+++ b/docs/NON-SECURE-PAYMENT-EXAMPLE.md
@@ -33,9 +33,6 @@ try {
     $config = require __DIR__.'/pos_test_ayarlar.php';
 
     $pos = \Mews\Pos\Factory\PosFactory::createPosGateway($account, $config, $eventDispatcher);
-
-    // GarantiPos'u test ortamda test edebilmek için zorunlu.
-    $pos->setTestMode(true);
 } catch (\Mews\Pos\Exceptions\BankNotFoundException | \Mews\Pos\Exceptions\BankClassNullException $e) {
     var_dump($e));
     exit;

--- a/docs/ORDER-HISTORY-EXAMPLE.md
+++ b/docs/ORDER-HISTORY-EXAMPLE.md
@@ -30,9 +30,6 @@ try {
     $config = require __DIR__.'/pos_test_ayarlar.php';
 
     $pos = \Mews\Pos\Factory\PosFactory::createPosGateway($account, $config, $eventDispatcher);
-
-    // GarantiPos'u test ortamda test edebilmek için zorunlu.
-    $pos->setTestMode(true);
 } catch (\Mews\Pos\Exceptions\BankNotFoundException | \Mews\Pos\Exceptions\BankClassNullException $e) {
     var_dump($e));
     exit;

--- a/docs/PRE-AUTH-POST-EXAMPLE.md
+++ b/docs/PRE-AUTH-POST-EXAMPLE.md
@@ -42,9 +42,6 @@ try {
     $config = require __DIR__.'/pos_test_ayarlar.php';
 
     $pos = \Mews\Pos\Factory\PosFactory::createPosGateway($account, $config, $eventDispatcher);
-
-    // GarantiPos'u test ortamda test edebilmek için zorunlu.
-    $pos->setTestMode(true);
 } catch (\Mews\Pos\Exceptions\BankNotFoundException | \Mews\Pos\Exceptions\BankClassNullException $e) {
     var_dump($e));
     exit;
@@ -184,8 +181,13 @@ try  {
         $session->set('last_response', $response);
     }
 } catch (\Mews\Pos\Exceptions\HashMismatchException $e) {
-   // Bankadan gelen verilerin bankaya ait olmadığında bu exception oluşur.
-   // Banka API bilgileriniz hatalı ise de oluşur.
+    /**
+     * Bankadan gelen verilerin bankaya ait olmadığında bu exception oluşur.
+     * Veya Banka API bilgileriniz hatalı ise de oluşur.
+     * Eğer kütühaneden dolayı hash doğrulama hatası alıyorsanız, issue oluşturunuz.
+     * Issue çözülene kadar geçici olarak disable_3d_hash_check: true ayarla hash doğrulamasını devre dışı bırakabilirsiniz.
+     * Güvenlik açısından disable_3d_hash_check: false olarak kullanılması tavsiye edilmez.
+     */
 } catch (\Exception|\Error $e) {
     var_dump($e);
     exit;

--- a/docs/REFUND-EXAMPLE.md
+++ b/docs/REFUND-EXAMPLE.md
@@ -30,9 +30,6 @@ try {
     $config = require __DIR__.'/pos_test_ayarlar.php';
 
     $pos = \Mews\Pos\Factory\PosFactory::createPosGateway($account, $config, $eventDispatcher);
-
-    // GarantiPos'u test ortamda test edebilmek için zorunlu.
-    $pos->setTestMode(true);
 } catch (\Mews\Pos\Exceptions\BankNotFoundException | \Mews\Pos\Exceptions\BankClassNullException $e) {
     var_dump($e));
     exit;

--- a/docs/STATUS-EXAMPLE.md
+++ b/docs/STATUS-EXAMPLE.md
@@ -30,9 +30,6 @@ try {
     $config = require __DIR__.'/pos_test_ayarlar.php';
 
     $pos = \Mews\Pos\Factory\PosFactory::createPosGateway($account, $config, $eventDispatcher);
-
-    // GarantiPos'u test ortamda test edebilmek için zorunlu.
-    $pos->setTestMode(true);
 } catch (\Mews\Pos\Exceptions\BankNotFoundException | \Mews\Pos\Exceptions\BankClassNullException $e) {
     var_dump($e));
     exit;

--- a/docs/THREED-PAYMENT-EXAMPLE.md
+++ b/docs/THREED-PAYMENT-EXAMPLE.md
@@ -50,9 +50,6 @@ try {
     $config = require __DIR__.'/pos_test_ayarlar.php';
 
     $pos = \Mews\Pos\Factory\PosFactory::createPosGateway($account, $config, $eventDispatcher);
-
-    // GarantiPos'u test ortamda test edebilmek için zorunlu.
-    $pos->setTestMode(true);
 } catch (\Mews\Pos\Exceptions\BankNotFoundException | \Mews\Pos\Exceptions\BankClassNullException $e) {
     var_dump($e);
     exit;
@@ -328,8 +325,13 @@ try  {
         // NOT: Ödeme durum sorgulama, iptal ve iade işlemleri yapacaksanız $response değerini saklayınız.
     }
 } catch (\Mews\Pos\Exceptions\HashMismatchException $e) {
-   // Bankadan gelen verilerin bankaya ait olmadığında bu exception oluşur.
-   // veya Banka API bilgileriniz hatalı ise de oluşur.
+    /**
+     * Bankadan gelen verilerin bankaya ait olmadığında bu exception oluşur.
+     * Veya Banka API bilgileriniz hatalı ise de oluşur.
+     * Eğer kütühaneden dolayı hash doğrulama hatası alıyorsanız, issue oluşturunuz.
+     * Issue çözülene kadar geçici olarak disable_3d_hash_check: true ayarla hash doğrulamasını devre dışı bırakabilirsiniz.
+     * Güvenlik açısından disable_3d_hash_check: false olarak kullanılması tavsiye edilmez.
+     */
 } catch (\Error $e) {
     var_dump($e);
     exit;

--- a/docs/THREED-SECURE-AND-PAY-PAYMENT-IN-MODALBOX-EXAMPLE.md
+++ b/docs/THREED-SECURE-AND-PAY-PAYMENT-IN-MODALBOX-EXAMPLE.md
@@ -48,9 +48,6 @@ try {
     $config = require __DIR__.'/pos_test_ayarlar.php';
 
     $pos = \Mews\Pos\Factory\PosFactory::createPosGateway($account, $config, $eventDispatcher);
-
-    // GarantiPos'u test ortamda test edebilmek için zorunlu.
-    $pos->setTestMode(true);
 } catch (\Mews\Pos\Exceptions\BankNotFoundException | \Mews\Pos\Exceptions\BankClassNullException $e) {
     var_dump($e));
     exit;
@@ -298,6 +295,13 @@ try  {
     // Sonuç çıktısı
     $response = $pos->getResponse();
 } catch (Mews\Pos\Exceptions\HashMismatchException $e) {
+    /**
+     * Bankadan gelen verilerin bankaya ait olmadığında bu exception oluşur.
+     * Veya Banka API bilgileriniz hatalı ise de oluşur.
+     * Eğer kütühaneden dolayı hash doğrulama hatası alıyorsanız, issue oluşturunuz.
+     * Issue çözülene kadar geçici olarak disable_3d_hash_check: true ayarla hash doğrulamasını devre dışı bırakabilirsiniz.
+     * Güvenlik açısından disable_3d_hash_check: false olarak kullanılması tavsiye edilmez.
+     */
 }
 ?>
 

--- a/examples/_main_config.php
+++ b/examples/_main_config.php
@@ -80,7 +80,6 @@ function getGateway(\Mews\Pos\Entity\Account\AbstractPosAccount $account, \Psr\E
         global $logger;
 
         $pos = \Mews\Pos\Factory\PosFactory::createPosGateway($account, $config, $eventDispatcher, null, $logger);
-        $pos->setTestMode(true);
 
         return $pos;
     } catch (Exception $e) {

--- a/examples/_templates/_payment_secure_response.php
+++ b/examples/_templates/_payment_secure_response.php
@@ -89,6 +89,13 @@ if (get_class($pos) === \Mews\Pos\Gateways\PayFlexV4Pos::class) {
 try {
     doPayment($pos, $paymentModel, $transaction, $order, $card);
 } catch (HashMismatchException $e) {
+    /**
+     * Bankadan gelen verilerin bankaya ait olmadığında bu exception oluşur.
+     * Veya Banka API bilgileriniz hatalı ise de oluşur.
+     * Eğer kütühaneden dolayı hash doğrulama hatası alıyorsanız, issue oluşturunuz.
+     * Issue çözülene kadar geçici olarak disable_3d_hash_check: true ayarla hash doğrulamasını devre dışı bırakabilirsiniz.
+     * Güvenlik açısından disable_3d_hash_check: false olarak kullanılması tavsiye edilmez.
+     */
     dd($e);
 } catch (\Exception|\Error $e) {
     dd($e);

--- a/examples/finansbank-payfor/_payment_config.php
+++ b/examples/finansbank-payfor/_payment_config.php
@@ -16,4 +16,21 @@ $testCards = [
         'name' => 'John Doe',
         'type' => CreditCardInterface::CARD_TYPE_VISA,
     ],
+//    'ziraat-katilim-1' => [
+//        OTP: 123456
+//        'number' => '5352480048848060',
+//        'year' => '31',
+//        'month' => '09',
+//        'cvv' => '131',
+//        'name' => 'John Doe',
+//        'type' => CreditCardInterface::CARD_TYPE_VISA,
+//    ],
+//    'ziraat-katilim-2' => [
+//        'number' => '9792096695823360',
+//        'year' => '29',
+//        'month' => '03',
+//        'cvv' => '123',
+//        'name' => 'John Doe',
+//        'type' => CreditCardInterface::CARD_TYPE_TROY,
+//    ],
 ];

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
-        bootstrap="vendor/autoload.php"
+        bootstrap="tests/bootstrap.php"
         backupGlobals="false"
         backupStaticAttributes="false"
         colors="true"

--- a/src/Gateways/AkbankPos.php
+++ b/src/Gateways/AkbankPos.php
@@ -95,7 +95,10 @@ class AkbankPos extends AbstractGateway
             return $this;
         }
 
-        if (!$this->requestDataMapper->getCrypt()->check3DHash($this->account, $request->all())) {
+        if (
+            !$this->is3DHashCheckDisabled()
+            && !$this->requestDataMapper->getCrypt()->check3DHash($this->account, $request->all())
+        ) {
             throw new HashMismatchException();
         }
 
@@ -145,7 +148,10 @@ class AkbankPos extends AbstractGateway
      */
     public function make3DPayPayment(Request $request, array $order, string $txType): PosInterface
     {
-        if (!$this->requestDataMapper->getCrypt()->check3DHash($this->account, $request->request->all())) {
+        if (
+            !$this->is3DHashCheckDisabled()
+            && !$this->requestDataMapper->getCrypt()->check3DHash($this->account, $request->request->all())
+        ) {
             throw new HashMismatchException();
         }
 
@@ -159,7 +165,10 @@ class AkbankPos extends AbstractGateway
      */
     public function make3DHostPayment(Request $request, array $order, string $txType): PosInterface
     {
-        if (!$this->requestDataMapper->getCrypt()->check3DHash($this->account, $request->request->all())) {
+        if (
+            !$this->is3DHashCheckDisabled()
+            && !$this->requestDataMapper->getCrypt()->check3DHash($this->account, $request->request->all())
+        ) {
             throw new HashMismatchException();
         }
 

--- a/src/Gateways/EstPos.php
+++ b/src/Gateways/EstPos.php
@@ -85,7 +85,10 @@ class EstPos extends AbstractGateway
             return $this;
         }
 
-        if (!$this->requestDataMapper->getCrypt()->check3DHash($this->account, $request->all())) {
+        if (
+            !$this->is3DHashCheckDisabled()
+            && !$this->requestDataMapper->getCrypt()->check3DHash($this->account, $request->all())
+        ) {
             throw new HashMismatchException();
         }
 
@@ -138,7 +141,10 @@ class EstPos extends AbstractGateway
      */
     public function make3DPayPayment(Request $request, array $order, string $txType): PosInterface
     {
-        if (!$this->requestDataMapper->getCrypt()->check3DHash($this->account, $request->request->all())) {
+        if (
+            !$this->is3DHashCheckDisabled()
+            && !$this->requestDataMapper->getCrypt()->check3DHash($this->account, $request->request->all())
+        ) {
             throw new HashMismatchException();
         }
 
@@ -152,7 +158,10 @@ class EstPos extends AbstractGateway
      */
     public function make3DHostPayment(Request $request, array $order, string $txType): PosInterface
     {
-        if (!$this->requestDataMapper->getCrypt()->check3DHash($this->account, $request->request->all())) {
+        if (
+            !$this->is3DHashCheckDisabled()
+            && !$this->requestDataMapper->getCrypt()->check3DHash($this->account, $request->request->all())
+        ) {
             throw new HashMismatchException();
         }
 

--- a/src/Gateways/GarantiPos.php
+++ b/src/Gateways/GarantiPos.php
@@ -78,7 +78,10 @@ class GarantiPos extends AbstractGateway
             return $this;
         }
 
-        if (!$this->requestDataMapper->getCrypt()->check3DHash($this->account, $request->all())) {
+        if (
+            !$this->is3DHashCheckDisabled()
+            && !$this->requestDataMapper->getCrypt()->check3DHash($this->account, $request->all())
+        ) {
             throw new HashMismatchException();
         }
 

--- a/src/Gateways/InterPos.php
+++ b/src/Gateways/InterPos.php
@@ -83,7 +83,10 @@ class InterPos extends AbstractGateway
             return $this;
         }
 
-        if (!$this->requestDataMapper->getCrypt()->check3DHash($this->account, $gatewayResponse)) {
+        if (
+            !$this->is3DHashCheckDisabled()
+            && !$this->requestDataMapper->getCrypt()->check3DHash($this->account, $gatewayResponse)
+        ) {
             throw new HashMismatchException();
         }
 

--- a/src/Gateways/ParamPos.php
+++ b/src/Gateways/ParamPos.php
@@ -109,7 +109,10 @@ class ParamPos extends AbstractGateway
             return $this;
         }
 
-        if (!$this->requestDataMapper->getCrypt()->check3DHash($this->account, $request->all())) {
+        if (
+            !$this->is3DHashCheckDisabled()
+            && !$this->requestDataMapper->getCrypt()->check3DHash($this->account, $request->all())
+        ) {
             throw new HashMismatchException();
         }
 
@@ -159,7 +162,10 @@ class ParamPos extends AbstractGateway
      */
     public function make3DPayPayment(Request $request, array $order, string $txType): PosInterface
     {
-        if (!$this->requestDataMapper->getCrypt()->check3DHash($this->account, $request->request->all())) {
+        if (
+            !$this->is3DHashCheckDisabled()
+            && !$this->requestDataMapper->getCrypt()->check3DHash($this->account, $request->request->all())
+        ) {
             throw new HashMismatchException();
         }
 
@@ -173,7 +179,10 @@ class ParamPos extends AbstractGateway
      */
     public function make3DHostPayment(Request $request, array $order, string $txType): PosInterface
     {
-        if (!$this->requestDataMapper->getCrypt()->check3DHash($this->account, $request->request->all())) {
+        if (
+            !$this->is3DHashCheckDisabled()
+            && !$this->requestDataMapper->getCrypt()->check3DHash($this->account, $request->request->all())
+        ) {
             throw new HashMismatchException();
         }
 

--- a/src/Gateways/PayForPos.php
+++ b/src/Gateways/PayForPos.php
@@ -78,7 +78,10 @@ class PayForPos extends AbstractGateway
             return $this;
         }
 
-        if (!$this->requestDataMapper->getCrypt()->check3DHash($this->account, $request->all())) {
+        if (
+            !$this->is3DHashCheckDisabled()
+            && !$this->requestDataMapper->getCrypt()->check3DHash($this->account, $request->all())
+        ) {
             throw new HashMismatchException();
         }
 

--- a/src/Gateways/PosNet.php
+++ b/src/Gateways/PosNet.php
@@ -109,7 +109,10 @@ class PosNet extends AbstractGateway
             return $this;
         }
 
-        if (!$this->requestDataMapper->getCrypt()->check3DHash($this->account, $userVerifyResponse['oosResolveMerchantDataResponse'])) {
+        if (
+            !$this->is3DHashCheckDisabled()
+            && !$this->requestDataMapper->getCrypt()->check3DHash($this->account, $userVerifyResponse['oosResolveMerchantDataResponse'])
+        ) {
             throw new HashMismatchException();
         }
 

--- a/src/Gateways/PosNetV1Pos.php
+++ b/src/Gateways/PosNetV1Pos.php
@@ -91,7 +91,10 @@ class PosNetV1Pos extends AbstractGateway
             return $this;
         }
 
-        if (!$this->requestDataMapper->getCrypt()->check3DHash($this->account, $request->all())) {
+        if (
+            !$this->is3DHashCheckDisabled()
+            && !$this->requestDataMapper->getCrypt()->check3DHash($this->account, $request->all())
+        ) {
             throw new HashMismatchException();
         }
 

--- a/src/Gateways/ToslaPos.php
+++ b/src/Gateways/ToslaPos.php
@@ -114,7 +114,11 @@ class ToslaPos extends AbstractGateway
     {
         $request = $request->request;
 
-        if ($this->is3DAuthSuccess($request->all()) && !$this->requestDataMapper->getCrypt()->check3DHash($this->account, $request->all())) {
+        if (
+            $this->is3DAuthSuccess($request->all())
+            && !$this->is3DHashCheckDisabled()
+            && !$this->requestDataMapper->getCrypt()->check3DHash($this->account, $request->all())
+        ) {
             throw new HashMismatchException();
         }
 
@@ -132,7 +136,11 @@ class ToslaPos extends AbstractGateway
     {
         $request = $request->request;
 
-        if ($this->is3DAuthSuccess($request->all()) && !$this->requestDataMapper->getCrypt()->check3DHash($this->account, $request->all())) {
+        if (
+            $this->is3DAuthSuccess($request->all())
+            && !$this->is3DHashCheckDisabled()
+            && !$this->requestDataMapper->getCrypt()->check3DHash($this->account, $request->all())
+        ) {
             throw new HashMismatchException();
         }
 

--- a/src/PosInterface.php
+++ b/src/PosInterface.php
@@ -329,6 +329,8 @@ interface PosInterface
      * @param bool $testMode
      *
      * @return PosInterface
+     *
+     * @deprecated set via configuration file instead.
      */
     public function setTestMode(bool $testMode): PosInterface;
 

--- a/tests/Functional/GarantiPosTest.php
+++ b/tests/Functional/GarantiPosTest.php
@@ -49,7 +49,6 @@ class GarantiPosTest extends TestCase
         $this->eventDispatcher = new EventDispatcher();
 
         $this->pos = PosFactory::createPosGateway($account, $config, $this->eventDispatcher);
-        $this->pos->setTestMode(true);
 
         $this->card = CreditCardFactory::createForGateway(
             $this->pos,

--- a/tests/Unit/Gateways/AkbankPosTest.php
+++ b/tests/Unit/Gateways/AkbankPosTest.php
@@ -112,8 +112,6 @@ class AkbankPosTest extends TestCase
             $this->loggerMock,
         );
 
-        $this->pos->setTestMode(true);
-
         $this->card = CreditCardFactory::create('5555444433332222', '21', '12', '122', 'ahmet', CreditCardInterface::CARD_TYPE_VISA);
     }
 

--- a/tests/Unit/Gateways/EstPosTest.php
+++ b/tests/Unit/Gateways/EstPosTest.php
@@ -10,6 +10,7 @@ use Mews\Pos\Client\HttpClient;
 use Mews\Pos\Crypt\CryptInterface;
 use Mews\Pos\DataMapper\RequestDataMapper\RequestDataMapperInterface;
 use Mews\Pos\DataMapper\ResponseDataMapper\ResponseDataMapperInterface;
+use Mews\Pos\Entity\Account\AbstractPosAccount;
 use Mews\Pos\Entity\Account\EstPosAccount;
 use Mews\Pos\Entity\Card\CreditCardInterface;
 use Mews\Pos\Event\RequestDataPreparedEvent;
@@ -113,16 +114,7 @@ class EstPosTest extends TestCase
             ->method('getCrypt')
             ->willReturn($this->cryptMock);
 
-        $this->pos = new EstPos(
-            $this->config,
-            $this->account,
-            $this->requestMapperMock,
-            $this->responseMapperMock,
-            $this->serializerMock,
-            $this->eventDispatcherMock,
-            $this->httpClientMock,
-            $this->loggerMock,
-        );
+        $this->pos = $this->createGateway($this->config);
 
         $this->card = CreditCardFactory::createForGateway(
             $this->pos,
@@ -132,6 +124,20 @@ class EstPosTest extends TestCase
             '122',
             'ahmet',
             CreditCardInterface::CARD_TYPE_VISA
+        );
+    }
+
+    private function createGateway(array $config, ?AbstractPosAccount $account = null): PosInterface
+    {
+        return new EstPos(
+            $config,
+            $account ?? $this->account,
+            $this->requestMapperMock,
+            $this->responseMapperMock,
+            $this->serializerMock,
+            $this->eventDispatcherMock,
+            $this->httpClientMock,
+            $this->loggerMock,
         );
     }
 
@@ -146,6 +152,7 @@ class EstPosTest extends TestCase
         $this->assertSame([PosInterface::CURRENCY_TRY], $this->pos->getCurrencies());
         $this->assertSame($this->config, $this->pos->getConfig());
         $this->assertSame($this->account, $this->pos->getAccount());
+        $this->assertFalse($this->pos->isTestMode());
     }
 
     /**
@@ -225,6 +232,40 @@ class EstPosTest extends TestCase
         $this->assertTrue($pos->isSuccess());
     }
 
+    /**
+     * @return void
+     */
+    public function testMake3DHostPaymentWithoutHashCheckSuccess(): void
+    {
+        $config = $this->config;
+        $config += [
+            'gateway_configs' => [
+                'disable_3d_hash_check' => true,
+            ],
+        ];
+
+        $pos = $this->createGateway($config);
+
+        $this->cryptMock->expects(self::never())
+            ->method('check3DHash');
+
+        $testData = EstPosResponseDataMapperTest::threeDHostPaymentDataProvider()['success1'];
+        $request  = Request::create('', 'POST', $testData['paymentData']);
+        $order    = $testData['order'];
+        $txType   = $testData['txType'];
+
+        $this->responseMapperMock->expects(self::once())
+            ->method('map3DHostResponseData')
+            ->with($request->request->all(), $txType, $order)
+            ->willReturn($testData['expectedData']);
+
+        $pos->make3DHostPayment($request, $order, $txType);
+
+        $result = $pos->getResponse();
+        $this->assertSame($testData['expectedData'], $result);
+        $this->assertTrue($pos->isSuccess());
+    }
+
     public function testMake3DHostPaymentHashMismatchException(): void
     {
         $data = EstPosResponseDataMapperTest::threeDHostPaymentDataProvider()['success1']['paymentData'];
@@ -262,6 +303,40 @@ class EstPosTest extends TestCase
             ->willReturn($testData['expectedData']);
 
         $pos = $this->pos;
+
+        $pos->make3DPayPayment($request, $order, $txType);
+
+        $result = $pos->getResponse();
+        $this->assertSame($testData['expectedData'], $result);
+        $this->assertTrue($pos->isSuccess());
+    }
+
+    /**
+     * @return void
+     */
+    public function testMake3DPayPaymentWithoutHashCheckSuccess(): void
+    {
+        $config = $this->config;
+        $config += [
+            'gateway_configs' => [
+                'disable_3d_hash_check' => true,
+            ],
+        ];
+
+        $pos = $this->createGateway($config);
+
+        $this->cryptMock->expects(self::never())
+            ->method('check3DHash');
+
+        $testData = EstPosResponseDataMapperTest::threeDPayPaymentDataProvider()['success1'];
+        $request  = Request::create('', 'POST', $testData['paymentData']);
+        $order    = $testData['order'];
+        $txType   = $testData['txType'];
+
+        $this->responseMapperMock->expects(self::once())
+            ->method('map3DPayResponseData')
+            ->with($request->request->all(), $txType, $order)
+            ->willReturn($testData['expectedData']);
 
         $pos->make3DPayPayment($request, $order, $txType);
 
@@ -520,6 +595,86 @@ class EstPosTest extends TestCase
         $this->assertSame($isSuccess, $this->pos->isSuccess());
     }
 
+    /**
+     * @dataProvider make3DPaymentWithoutHashCheckDataProvider
+     */
+    public function testMake3DPaymentWithoutHashCheck(
+        array   $order,
+        string  $txType,
+        Request $request,
+        array   $paymentResponse,
+        array   $expectedResponse,
+        bool    $is3DSuccess,
+        bool    $isSuccess
+    ): void {
+        $config = $this->config;
+        $config += [
+            'gateway_configs' => [
+                'disable_3d_hash_check' => true,
+            ],
+        ];
+
+        $pos = $this->createGateway($config);
+
+        $this->cryptMock->expects(self::never())
+            ->method('check3DHash');
+
+        $this->responseMapperMock->expects(self::once())
+            ->method('extractMdStatus')
+            ->with($request->request->all())
+            ->willReturn('3d-status');
+
+        $this->responseMapperMock->expects(self::once())
+            ->method('is3dAuthSuccess')
+            ->with('3d-status')
+            ->willReturn($is3DSuccess);
+
+        $create3DPaymentRequestData = [
+            'create3DPaymentRequestData',
+        ];
+        if ($is3DSuccess) {
+            $this->requestMapperMock->expects(self::once())
+                ->method('create3DPaymentRequestData')
+                ->with($this->account, $order, $txType, $request->request->all())
+                ->willReturn($create3DPaymentRequestData);
+
+            $this->configureClientResponse(
+                $txType,
+                'https://entegrasyon.asseco-see.com.tr/fim/api',
+                $create3DPaymentRequestData,
+                'request-body',
+                'response-body',
+                $paymentResponse,
+                $order,
+                PosInterface::MODEL_3D_SECURE
+            );
+
+            $this->responseMapperMock->expects(self::once())
+                ->method('map3DPaymentData')
+                ->with($request->request->all(), $paymentResponse, $txType, $order)
+                ->willReturn($expectedResponse);
+        } else {
+            $this->responseMapperMock->expects(self::once())
+                ->method('map3DPaymentData')
+                ->with($request->request->all(), null, $txType, $order)
+                ->willReturn($expectedResponse);
+            $this->requestMapperMock->expects(self::never())
+                ->method('create3DPaymentRequestData');
+            $this->serializerMock->expects(self::never())
+                ->method('encode');
+            $this->serializerMock->expects(self::never())
+                ->method('decode');
+            $this->eventDispatcherMock->expects(self::never())
+                ->method('dispatch');
+        }
+
+        $pos->make3DPayment($request, $order, $txType);
+
+        $result = $pos->getResponse();
+        $this->assertSame($expectedResponse, $result);
+        $this->assertSame($isSuccess, $pos->isSuccess());
+    }
+
     public function testMake3DPaymentHashMismatchException(): void
     {
         $data = EstPosResponseDataMapperTest::threeDPaymentDataProvider()['3d_auth_success_payment_fail']['threeDResponseData'];
@@ -683,6 +838,38 @@ class EstPosTest extends TestCase
                 'is3DSuccess'     => false,
                 'isSuccess'       => false,
             ],
+            '3d_auth_success_payment_fail' => [
+                'order'           => EstPosResponseDataMapperTest::threeDPaymentDataProvider()['3d_auth_success_payment_fail']['order'],
+                'txType'          => EstPosResponseDataMapperTest::threeDPaymentDataProvider()['3d_auth_success_payment_fail']['txType'],
+                'request'         => Request::create(
+                    '',
+                    'POST',
+                    EstPosResponseDataMapperTest::threeDPaymentDataProvider()['3d_auth_success_payment_fail']['threeDResponseData']
+                ),
+                'paymentResponse' => EstPosResponseDataMapperTest::threeDPaymentDataProvider()['3d_auth_success_payment_fail']['paymentData'],
+                'expected'        => EstPosResponseDataMapperTest::threeDPaymentDataProvider()['3d_auth_success_payment_fail']['expectedData'],
+                'is3DSuccess'     => true,
+                'isSuccess'       => false,
+            ],
+            'success'                      => [
+                'order'           => EstPosResponseDataMapperTest::threeDPaymentDataProvider()['success1']['order'],
+                'txType'          => EstPosResponseDataMapperTest::threeDPaymentDataProvider()['success1']['txType'],
+                'request'         => Request::create(
+                    '',
+                    'POST',
+                    EstPosResponseDataMapperTest::threeDPaymentDataProvider()['success1']['threeDResponseData']
+                ),
+                'paymentResponse' => EstPosResponseDataMapperTest::threeDPaymentDataProvider()['success1']['paymentData'],
+                'expected'        => EstPosResponseDataMapperTest::threeDPaymentDataProvider()['success1']['expectedData'],
+                'is3DSuccess'     => true,
+                'isSuccess'       => true,
+            ],
+        ];
+    }
+
+    public static function make3DPaymentWithoutHashCheckDataProvider(): array
+    {
+        return [
             '3d_auth_success_payment_fail' => [
                 'order'           => EstPosResponseDataMapperTest::threeDPaymentDataProvider()['3d_auth_success_payment_fail']['order'],
                 'txType'          => EstPosResponseDataMapperTest::threeDPaymentDataProvider()['3d_auth_success_payment_fail']['txType'],

--- a/tests/Unit/Gateways/EstPosTest.php
+++ b/tests/Unit/Gateways/EstPosTest.php
@@ -124,8 +124,6 @@ class EstPosTest extends TestCase
             $this->loggerMock,
         );
 
-        $this->pos->setTestMode(true);
-
         $this->card = CreditCardFactory::createForGateway(
             $this->pos,
             '5555444433332222',

--- a/tests/Unit/Gateways/GarantiPosTest.php
+++ b/tests/Unit/Gateways/GarantiPosTest.php
@@ -114,8 +114,6 @@ class GarantiPosTest extends TestCase
             $this->loggerMock,
         );
 
-        $this->pos->setTestMode(true);
-
         $this->card = CreditCardFactory::createForGateway(
             $this->pos,
             '5555444433332222',

--- a/tests/Unit/Gateways/GarantiPosTest.php
+++ b/tests/Unit/Gateways/GarantiPosTest.php
@@ -10,6 +10,7 @@ use Mews\Pos\Client\HttpClient;
 use Mews\Pos\Crypt\CryptInterface;
 use Mews\Pos\DataMapper\RequestDataMapper\RequestDataMapperInterface;
 use Mews\Pos\DataMapper\ResponseDataMapper\ResponseDataMapperInterface;
+use Mews\Pos\Entity\Account\AbstractPosAccount;
 use Mews\Pos\Entity\Account\GarantiPosAccount;
 use Mews\Pos\Entity\Card\CreditCardInterface;
 use Mews\Pos\Event\RequestDataPreparedEvent;
@@ -103,16 +104,7 @@ class GarantiPosTest extends TestCase
             ->method('getCrypt')
             ->willReturn($this->cryptMock);
 
-        $this->pos = new GarantiPos(
-            $this->config,
-            $this->account,
-            $this->requestMapperMock,
-            $this->responseMapperMock,
-            $this->serializerMock,
-            $this->eventDispatcherMock,
-            $this->httpClientMock,
-            $this->loggerMock,
-        );
+        $this->pos = $this->createGateway($this->config);
 
         $this->card = CreditCardFactory::createForGateway(
             $this->pos,
@@ -122,6 +114,20 @@ class GarantiPosTest extends TestCase
             '122',
             'ahmet',
             CreditCardInterface::CARD_TYPE_VISA
+        );
+    }
+
+    private function createGateway(array $config, ?AbstractPosAccount $account = null): PosInterface
+    {
+        return new GarantiPos(
+            $config,
+            $account ?? $this->account,
+            $this->requestMapperMock,
+            $this->responseMapperMock,
+            $this->serializerMock,
+            $this->eventDispatcherMock,
+            $this->httpClientMock,
+            $this->loggerMock,
         );
     }
 
@@ -136,6 +142,7 @@ class GarantiPosTest extends TestCase
         $this->assertSame([PosInterface::CURRENCY_TRY], $this->pos->getCurrencies());
         $this->assertSame($this->config, $this->pos->getConfig());
         $this->assertSame($this->account, $this->pos->getAccount());
+        $this->assertFalse($this->pos->isTestMode());
     }
 
     /**
@@ -260,6 +267,88 @@ class GarantiPosTest extends TestCase
         $result = $this->pos->getResponse();
         $this->assertSame($expectedResponse, $result);
         $this->assertSame($isSuccess, $this->pos->isSuccess());
+    }
+
+
+    /**
+     * @dataProvider make3DPaymentWithoutHashCheckDataProvider
+     */
+    public function testMake3DPaymentWithoutHashCheck(
+        array   $order,
+        string  $txType,
+        Request $request,
+        array   $paymentResponse,
+        array   $expectedResponse,
+        bool    $is3DSuccess,
+        bool    $isSuccess
+    ): void {
+        $config = $this->config;
+        $config += [
+            'gateway_configs' => [
+                'disable_3d_hash_check' => true,
+            ],
+        ];
+
+        $pos = $this->createGateway($config);
+
+        $this->cryptMock->expects(self::never())
+            ->method('check3DHash');
+
+        $this->responseMapperMock->expects(self::once())
+            ->method('extractMdStatus')
+            ->with($request->request->all())
+            ->willReturn('3d-status');
+
+        $this->responseMapperMock->expects(self::once())
+            ->method('is3dAuthSuccess')
+            ->with('3d-status')
+            ->willReturn($is3DSuccess);
+
+        $create3DPaymentRequestData = [
+            'create3DPaymentRequestData',
+        ];
+
+        if ($is3DSuccess) {
+            $this->requestMapperMock->expects(self::once())
+                ->method('create3DPaymentRequestData')
+                ->with($this->account, $order, $txType, $request->request->all())
+                ->willReturn($create3DPaymentRequestData);
+
+            $this->configureClientResponse(
+                $txType,
+                $this->config['gateway_endpoints']['payment_api'],
+                $create3DPaymentRequestData,
+                'request-body',
+                'response-body',
+                $paymentResponse,
+                $order,
+                PosInterface::MODEL_3D_SECURE
+            );
+
+            $this->responseMapperMock->expects(self::once())
+                ->method('map3DPaymentData')
+                ->with($request->request->all(), $paymentResponse, $txType, $order)
+                ->willReturn($expectedResponse);
+        } else {
+            $this->responseMapperMock->expects(self::once())
+                ->method('map3DPaymentData')
+                ->with($request->request->all(), null, $txType, $order)
+                ->willReturn($expectedResponse);
+            $this->requestMapperMock->expects(self::never())
+                ->method('create3DPaymentRequestData');
+            $this->serializerMock->expects(self::never())
+                ->method('encode');
+            $this->serializerMock->expects(self::never())
+                ->method('decode');
+            $this->eventDispatcherMock->expects(self::never())
+                ->method('dispatch');
+        }
+
+        $pos->make3DPayment($request, $order, $txType);
+
+        $result = $pos->getResponse();
+        $this->assertSame($expectedResponse, $result);
+        $this->assertSame($isSuccess, $pos->isSuccess());
     }
 
     public function testMake3DPaymentHashMismatchException(): void
@@ -629,6 +718,38 @@ class GarantiPosTest extends TestCase
                 'is3DSuccess'     => false,
                 'isSuccess'       => false,
             ],
+            '3d_auth_success_payment_fail' => [
+                'order'           => GarantiPosResponseDataMapperTest::threeDPaymentDataProvider()['paymentFail1']['order'],
+                'txType'          => GarantiPosResponseDataMapperTest::threeDPaymentDataProvider()['paymentFail1']['txType'],
+                'request'         => Request::create(
+                    '',
+                    'POST',
+                    GarantiPosResponseDataMapperTest::threeDPaymentDataProvider()['paymentFail1']['threeDResponseData']
+                ),
+                'paymentResponse' => GarantiPosResponseDataMapperTest::threeDPaymentDataProvider()['paymentFail1']['paymentData'],
+                'expected'        => GarantiPosResponseDataMapperTest::threeDPaymentDataProvider()['paymentFail1']['expectedData'],
+                'is3DSuccess'     => true,
+                'isSuccess'       => false,
+            ],
+            'success'                      => [
+                'order'           => GarantiPosResponseDataMapperTest::threeDPaymentDataProvider()['success1']['order'],
+                'txType'          => GarantiPosResponseDataMapperTest::threeDPaymentDataProvider()['success1']['txType'],
+                'request'         => Request::create(
+                    '',
+                    'POST',
+                    GarantiPosResponseDataMapperTest::threeDPaymentDataProvider()['success1']['threeDResponseData']
+                ),
+                'paymentResponse' => GarantiPosResponseDataMapperTest::threeDPaymentDataProvider()['success1']['paymentData'],
+                'expected'        => GarantiPosResponseDataMapperTest::threeDPaymentDataProvider()['success1']['expectedData'],
+                'is3DSuccess'     => true,
+                'isSuccess'       => true,
+            ],
+        ];
+    }
+
+    public static function make3DPaymentWithoutHashCheckDataProvider(): array
+    {
+        return [
             '3d_auth_success_payment_fail' => [
                 'order'           => GarantiPosResponseDataMapperTest::threeDPaymentDataProvider()['paymentFail1']['order'],
                 'txType'          => GarantiPosResponseDataMapperTest::threeDPaymentDataProvider()['paymentFail1']['txType'],

--- a/tests/Unit/Gateways/InterPosTest.php
+++ b/tests/Unit/Gateways/InterPosTest.php
@@ -130,8 +130,6 @@ class InterPosTest extends TestCase
             $this->loggerMock,
         );
 
-        $this->pos->setTestMode(true);
-
         $this->card = CreditCardFactory::createForGateway($this->pos, '5555444433332222', '21', '12', '122', 'ahmet', CreditCardInterface::CARD_TYPE_VISA);
     }
 

--- a/tests/Unit/Gateways/KuveytPosTest.php
+++ b/tests/Unit/Gateways/KuveytPosTest.php
@@ -152,6 +152,7 @@ class KuveytPosTest extends TestCase
         $this->assertSame([PosInterface::CURRENCY_TRY], $this->pos->getCurrencies());
         $this->assertSame($this->config, $this->pos->getConfig());
         $this->assertSame($this->account, $this->pos->getAccount());
+        $this->assertFalse($this->pos->isTestMode());
     }
 
     /**

--- a/tests/Unit/Gateways/KuveytPosTest.php
+++ b/tests/Unit/Gateways/KuveytPosTest.php
@@ -130,8 +130,6 @@ class KuveytPosTest extends TestCase
             $this->loggerMock,
         );
 
-        $this->pos->setTestMode(true);
-
         $this->card = CreditCardFactory::createForGateway(
             $this->pos,
             '4155650100416111',

--- a/tests/Unit/Gateways/PayFlexCPV4PosTest.php
+++ b/tests/Unit/Gateways/PayFlexCPV4PosTest.php
@@ -127,8 +127,6 @@ class PayFlexCPV4PosTest extends TestCase
             $this->loggerMock,
         );
 
-        $this->pos->setTestMode(true);
-
         $this->card = CreditCardFactory::createForGateway($this->pos, '5555444433332222', '2021', '12', '122', 'ahmet', CreditCardInterface::CARD_TYPE_VISA);
     }
 

--- a/tests/Unit/Gateways/PayFlexCPV4PosTest.php
+++ b/tests/Unit/Gateways/PayFlexCPV4PosTest.php
@@ -141,6 +141,7 @@ class PayFlexCPV4PosTest extends TestCase
         $this->assertSame([PosInterface::CURRENCY_TRY], $this->pos->getCurrencies());
         $this->assertSame($this->config, $this->pos->getConfig());
         $this->assertSame($this->account, $this->pos->getAccount());
+        $this->assertFalse($this->pos->isTestMode());
     }
 
     /**

--- a/tests/Unit/Gateways/PayFlexV4PosTest.php
+++ b/tests/Unit/Gateways/PayFlexV4PosTest.php
@@ -127,8 +127,6 @@ class PayFlexV4PosTest extends TestCase
             $this->loggerMock,
         );
 
-        $this->pos->setTestMode(true);
-
         $this->card = CreditCardFactory::create(
             '5555444433332222',
             '2021',

--- a/tests/Unit/Gateways/PayFlexV4PosTest.php
+++ b/tests/Unit/Gateways/PayFlexV4PosTest.php
@@ -148,6 +148,7 @@ class PayFlexV4PosTest extends TestCase
         $this->assertSame([PosInterface::CURRENCY_TRY], $this->pos->getCurrencies());
         $this->assertSame($this->config, $this->pos->getConfig());
         $this->assertSame($this->account, $this->pos->getAccount());
+        $this->assertFalse($this->pos->isTestMode());
     }
 
     /**

--- a/tests/Unit/Gateways/PayForTest.php
+++ b/tests/Unit/Gateways/PayForTest.php
@@ -113,8 +113,6 @@ class PayForTest extends TestCase
             $this->loggerMock,
         );
 
-        $this->pos->setTestMode(true);
-
         $this->card = CreditCardFactory::createForGateway(
             $this->pos,
             '5555444433332222',

--- a/tests/Unit/Gateways/PosNetTest.php
+++ b/tests/Unit/Gateways/PosNetTest.php
@@ -127,8 +127,6 @@ class PosNetTest extends TestCase
             $this->loggerMock,
         );
 
-        $this->pos->setTestMode(true);
-
         $this->card = CreditCardFactory::createForGateway($this->pos, '5555444433332222', '21', '12', '122', 'ahmet');
     }
 

--- a/tests/Unit/Gateways/PosNetV1PosTest.php
+++ b/tests/Unit/Gateways/PosNetV1PosTest.php
@@ -112,8 +112,6 @@ class PosNetV1PosTest extends TestCase
             $this->loggerMock,
         );
 
-        $this->pos->setTestMode(true);
-
         $this->card = CreditCardFactory::createForGateway($this->pos, '5555444433332222', '21', '12', '122', 'ahmet');
     }
 

--- a/tests/Unit/Gateways/ToslaPosTest.php
+++ b/tests/Unit/Gateways/ToslaPosTest.php
@@ -113,8 +113,6 @@ class ToslaPosTest extends TestCase
             $this->loggerMock,
         );
 
-        $this->pos->setTestMode(true);
-
         $this->card = CreditCardFactory::createForGateway($this->pos, '5555444433332222', '21', '12', '122', 'ahmet', CreditCardInterface::CARD_TYPE_VISA);
     }
 

--- a/tests/Unit/Gateways/ToslaPosTest.php
+++ b/tests/Unit/Gateways/ToslaPosTest.php
@@ -10,6 +10,7 @@ use Mews\Pos\Client\HttpClient;
 use Mews\Pos\Crypt\CryptInterface;
 use Mews\Pos\DataMapper\RequestDataMapper\ToslaPosRequestDataMapper;
 use Mews\Pos\DataMapper\ResponseDataMapper\ResponseDataMapperInterface;
+use Mews\Pos\Entity\Account\AbstractPosAccount;
 use Mews\Pos\Entity\Account\ToslaPosAccount;
 use Mews\Pos\Entity\Card\CreditCardInterface;
 use Mews\Pos\Event\RequestDataPreparedEvent;
@@ -102,9 +103,16 @@ class ToslaPosTest extends TestCase
             ->method('getCrypt')
             ->willReturn($this->cryptMock);
 
-        $this->pos = new ToslaPos(
-            $this->config,
-            $this->account,
+        $this->pos = $this->createGateway($this->config);
+
+        $this->card = CreditCardFactory::createForGateway($this->pos, '5555444433332222', '21', '12', '122', 'ahmet', CreditCardInterface::CARD_TYPE_VISA);
+    }
+
+    private function createGateway(array $config, ?AbstractPosAccount $account = null): PosInterface
+    {
+        return new ToslaPos(
+            $config,
+            $account ?? $this->account,
             $this->requestMapperMock,
             $this->responseMapperMock,
             $this->serializerMock,
@@ -112,14 +120,13 @@ class ToslaPosTest extends TestCase
             $this->httpClientMock,
             $this->loggerMock,
         );
-
-        $this->card = CreditCardFactory::createForGateway($this->pos, '5555444433332222', '21', '12', '122', 'ahmet', CreditCardInterface::CARD_TYPE_VISA);
     }
 
     public function testInit(): void
     {
         $this->assertSame($this->config, $this->pos->getConfig());
         $this->assertSame($this->account, $this->pos->getAccount());
+        $this->assertFalse($this->pos->isTestMode());
     }
 
     /**
@@ -200,6 +207,50 @@ class ToslaPosTest extends TestCase
         $this->assertSame($isSuccess, $this->pos->isSuccess());
     }
 
+    /**
+     * @dataProvider make3DPayPaymentWithoutHashCheckDataProvider
+     */
+    public function testMake3DPayPaymentWithoutHashCheck(
+        array   $order,
+        string  $txType,
+        Request $request,
+        array   $expectedResponse,
+        bool    $is3DSuccess,
+        bool    $isSuccess
+    ): void {
+        $config = $this->config;
+        $config += [
+            'gateway_configs' => [
+                'disable_3d_hash_check' => true,
+            ],
+        ];
+
+        $pos = $this->createGateway($config);
+
+        $this->cryptMock->expects(self::never())
+            ->method('check3DHash');
+
+        $this->responseMapperMock->expects(self::once())
+            ->method('extractMdStatus')
+            ->with($request->request->all())
+            ->willReturn('3d-status');
+
+        $this->responseMapperMock->expects(self::once())
+            ->method('is3dAuthSuccess')
+            ->with('3d-status')
+            ->willReturn($is3DSuccess);
+
+        $this->responseMapperMock->expects(self::once())
+            ->method('map3DPayResponseData')
+            ->willReturn($expectedResponse);
+
+        $pos->make3DPayPayment($request, $order, $txType);
+
+        $result = $pos->getResponse();
+        $this->assertSame($expectedResponse, $result);
+        $this->assertSame($isSuccess, $pos->isSuccess());
+    }
+
     public function testMake3DPayPaymentHashMismatchException(): void
     {
         $data    = ToslaPosResponseDataMapperTest::threeDPayPaymentDataProvider()['success1']['paymentData'];
@@ -258,6 +309,50 @@ class ToslaPosTest extends TestCase
         $result = $this->pos->getResponse();
         $this->assertSame($expectedResponse, $result);
         $this->assertSame($isSuccess, $this->pos->isSuccess());
+    }
+
+    /**
+     * @dataProvider make3DPayPaymentWithoutHashCheckDataProvider
+     */
+    public function testMake3DHostPaymentWithoutHashCheck(
+        array   $order,
+        string  $txType,
+        Request $request,
+        array   $expectedResponse,
+        bool    $is3DSuccess,
+        bool    $isSuccess
+    ): void {
+        $config = $this->config;
+        $config += [
+            'gateway_configs' => [
+                'disable_3d_hash_check' => true,
+            ],
+        ];
+
+        $pos = $this->createGateway($config);
+
+        $this->cryptMock->expects(self::never())
+            ->method('check3DHash');
+
+        $this->responseMapperMock->expects(self::once())
+            ->method('extractMdStatus')
+            ->with($request->request->all())
+            ->willReturn('3d-status');
+
+        $this->responseMapperMock->expects(self::once())
+            ->method('is3dAuthSuccess')
+            ->with('3d-status')
+            ->willReturn($is3DSuccess);
+
+        $this->responseMapperMock->expects(self::once())
+            ->method('map3DHostResponseData')
+            ->willReturn($expectedResponse);
+
+        $pos->make3DHostPayment($request, $order, $txType);
+
+        $result = $pos->getResponse();
+        $this->assertSame($expectedResponse, $result);
+        $this->assertSame($isSuccess, $pos->isSuccess());
     }
 
     public function testMake3DHostPaymentHashMismatchException(): void
@@ -715,6 +810,24 @@ class ToslaPosTest extends TestCase
                 'is3DSuccess' => false,
                 'isSuccess'   => false,
             ],
+            'success'   => [
+                'order'       => ToslaPosResponseDataMapperTest::threeDPayPaymentDataProvider()['success1']['order'],
+                'txType'      => ToslaPosResponseDataMapperTest::threeDPayPaymentDataProvider()['success1']['txType'],
+                'request'     => Request::create(
+                    '',
+                    'POST',
+                    ToslaPosResponseDataMapperTest::threeDPayPaymentDataProvider()['success1']['paymentData']
+                ),
+                'expected'    => ToslaPosResponseDataMapperTest::threeDPayPaymentDataProvider()['success1']['expectedData'],
+                'is3DSuccess' => true,
+                'isSuccess'   => true,
+            ],
+        ];
+    }
+
+    public static function make3DPayPaymentWithoutHashCheckDataProvider(): array
+    {
+        return [
             'success'   => [
                 'order'       => ToslaPosResponseDataMapperTest::threeDPayPaymentDataProvider()['success1']['order'],
                 'txType'      => ToslaPosResponseDataMapperTest::threeDPayPaymentDataProvider()['success1']['txType'],

--- a/tests/Unit/Gateways/VakifKatilimTest.php
+++ b/tests/Unit/Gateways/VakifKatilimTest.php
@@ -126,8 +126,6 @@ class VakifKatilimTest extends TestCase
             $this->loggerMock,
         );
 
-        $this->pos->setTestMode(true);
-
         $this->card = CreditCardFactory::createForGateway(
             $this->pos,
             '4155650100416111',

--- a/tests/Unit/Gateways/VakifKatilimTest.php
+++ b/tests/Unit/Gateways/VakifKatilimTest.php
@@ -148,6 +148,7 @@ class VakifKatilimTest extends TestCase
         $this->assertSame([PosInterface::CURRENCY_TRY], $this->pos->getCurrencies());
         $this->assertSame($this->config, $this->pos->getConfig());
         $this->assertSame($this->account, $this->pos->getAccount());
+        $this->assertFalse($this->pos->isTestMode());
     }
 
     /**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,10 @@
+<?php
+
+use Symfony\Component\Dotenv\Dotenv;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+if (file_exists(__DIR__ . '/../.env')) {
+    $dotenv = new Dotenv();
+    $dotenv->load(__DIR__.'/../.env');
+}


### PR DESCRIPTION
- Kütüphane config dosyasına yeni `test_mode` ve `disable_3d_hash_check` ayarlar desteği eklendi.
  Örnek:
    ```php
    [
        'banks' => [
          'garanti' => [
            'name'              => 'Garanti',
            'class'             => Mews\Pos\Gateways\GarantiPos::class,
            'gateway_configs' => [
                'test_mode'             => true, // default: false
                // 3D hash kontrolü çalışmadığında geçici olarak kullanılabilir.
                'disable_3d_hash_check' => true, // default: false
             ],
             'gateway_endpoints' => [
                'payment_api' => 'https://sanalposprovtest.garantibbva.com.tr/VPServlet',
                'gateway_3d'  => 'https://sanalposprovtest.garantibbva.com.tr/servlet/gt3dengine',
             ],
          ],
        ]
    ]
    ```